### PR TITLE
feat(castable-video): Add castCustomData to send arbitrary custom data to receiver app on load.

### DIFF
--- a/packages/castable-video/castable-mixin.js
+++ b/packages/castable-video/castable-mixin.js
@@ -30,6 +30,7 @@ export const CastableMediaMixin = (superclass) =>
 
     #localState = { paused: false };
     #castOptions = getDefaultCastOptions();
+    #castCustomData;
     #remote;
 
     get remote() {
@@ -89,6 +90,7 @@ export const CastableMediaMixin = (superclass) =>
       if (!this.#castPlayer) return super.load();
 
       const mediaInfo = new chrome.cast.media.MediaInfo(this.castSrc, this.castContentType);
+      mediaInfo.customData = this.castCustomData;
 
       // Manually add text tracks with a `src` attribute.
       // M3U8's load text tracks in the receiver, handle these in the media loaded event.
@@ -219,6 +221,21 @@ export const CastableMediaMixin = (superclass) =>
 
     set castStreamType(val) {
       this.setAttribute('cast-stream-type', `${val}`);
+    }
+
+    get castCustomData() {
+      return this.#castCustomData;
+    }
+
+    set castCustomData(val) {
+      console.log('setting castCustomData', val);
+      const valType = typeof val;
+      if (!['object', 'undefined'].includes(valType)) {
+        console.error(`castCustomData must be nullish or an object but value was of type ${valType}`);
+        return;
+      }
+
+      this.#castCustomData = val;
     }
 
     get readyState() {

--- a/packages/castable-video/castable-mixin.js
+++ b/packages/castable-video/castable-mixin.js
@@ -228,7 +228,6 @@ export const CastableMediaMixin = (superclass) =>
     }
 
     set castCustomData(val) {
-      console.log('setting castCustomData', val);
       const valType = typeof val;
       if (!['object', 'undefined'].includes(valType)) {
         console.error(`castCustomData must be nullish or an object but value was of type ${valType}`);

--- a/packages/custom-media-element/test/test.js
+++ b/packages/custom-media-element/test/test.js
@@ -208,14 +208,16 @@ test('has HTMLVideoElement like properties', async function (t) {
     'videoHeight',
     'videoWidth',
     'volume',
-    'webkitAudioDecodedByteCount',
-    'webkitDecodedFrameCount',
-    'webkitDroppedFrameCount',
-    'webkitEnterFullScreen',
-    'webkitEnterFullscreen',
-    'webkitExitFullScreen',
-    'webkitExitFullscreen',
-    'webkitVideoDecodedByteCount',
+    // Commenting browser-prefixed properties out as we should not
+    // *assume* they will exist, even for the browser in question (CJP)
+    // 'webkitAudioDecodedByteCount',
+    // 'webkitDecodedFrameCount',
+    // 'webkitDroppedFrameCount',
+    // 'webkitEnterFullScreen',
+    // 'webkitEnterFullscreen',
+    // 'webkitExitFullScreen',
+    // 'webkitExitFullscreen',
+    // 'webkitVideoDecodedByteCount',
     'width',
   ];
 


### PR DESCRIPTION
See: https://developers.google.com/cast/docs/reference/web_sender/chrome.cast.media.MediaInfo#customData