### PR TITLE
Added event dispatch for youtube errors

### DIFF
--- a/packages/youtube-video-element/index.html
+++ b/packages/youtube-video-element/index.html
@@ -113,6 +113,9 @@
     video.addEventListener('resize', (e) => {
       console.log(e.type, video.videoWidth, video.videoHeight);
     });
+    video.addEventListener('error', (e) => {
+      console.log(e);
+    });
   </script>
 
 </body>

--- a/packages/youtube-video-element/index.html
+++ b/packages/youtube-video-element/index.html
@@ -1,40 +1,40 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>&lt;youtube-video&gt;</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <head>
+    <title>&lt;youtube-video&gt;</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link
     rel="stylesheet"
     href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"
   />
-  <style>
-    body {
-      text-align: center;
-    }
-    media-controller,
-    youtube-video {
-      display: block;
-      width: 100%;
-      aspect-ratio: 16 / 9;
-      background: #000;
-    }
-  </style>
-  <script type="module" src="./youtube-video-element.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/media-chrome/+esm"></script>
-</head>
-<body>
-  <h1>&lt;youtube-video&gt;</h1>
-  <br />
+    <style>
+      body {
+        text-align: center;
+      }
+      media-controller,
+      youtube-video {
+        display: block;
+        width: 100%;
+        aspect-ratio: 16 / 9;
+        background: #000;
+      }
+    </style>
+    <script type="module" src="./youtube-video-element.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/media-chrome/+esm"></script>
+  </head>
+  <body>
+    <h1>&lt;youtube-video&gt;</h1>
+    <br />
 
   <youtube-video id="yt1" muted controls src="https://www.youtube.com/watch?v=rubNgGj3pYo"></youtube-video>
 
   <br>
 
-  <button id="loadbtn">Load new clip</button>
+    <button id="loadbtn">Load new clip</button>
 
   <br>
 
-  <h2>With <a href="https://github.com/muxinc/media-chrome" target="_blank">Media Chrome</a></h2>
+    <h2>With <a href="https://github.com/muxinc/media-chrome" target="_blank">Media Chrome</a></h2>
 
   <media-controller>
     <youtube-video
@@ -43,80 +43,80 @@
       slot="media"
       autopause
     ></youtube-video>
-    <media-control-bar>
-      <media-play-button></media-play-button>
-      <media-seek-backward-button seek-offset="15"></media-seek-backward-button>
-      <media-seek-forward-button seek-offset="15"></media-seek-forward-button>
-      <media-mute-button></media-mute-button>
-      <media-volume-range></media-volume-range>
-      <media-time-range></media-time-range>
-      <media-time-display show-duration remaining></media-time-display>
-      <media-playback-rate-button></media-playback-rate-button>
-      <media-fullscreen-button></media-fullscreen-button>
-    </media-control-bar>
+      <media-control-bar>
+        <media-play-button></media-play-button>
+        <media-seek-backward-button seek-offset="15"></media-seek-backward-button>
+        <media-seek-forward-button seek-offset="15"></media-seek-forward-button>
+        <media-mute-button></media-mute-button>
+        <media-volume-range></media-volume-range>
+        <media-time-range></media-time-range>
+        <media-time-display show-duration remaining></media-time-display>
+        <media-playback-rate-button></media-playback-rate-button>
+        <media-fullscreen-button></media-fullscreen-button>
+      </media-control-bar>
   </media-controller>
 
   <br>
   <br>
 
-  <script>
+    <script>
     const video = document.querySelector('#yt2');
 
     window.addEventListener('load', function() {
-      document.querySelector('#yt1').currentTime = 23;
-    });
+        document.querySelector('#yt1').currentTime = 23;
+      });
 
-    loadbtn.onclick = () => {
-      video.src = 'https://www.youtube.com/watch?v=H3KSKS3TTbc';
-    }
+      loadbtn.onclick = () => {
+        video.src = 'https://www.youtube.com/watch?v=H3KSKS3TTbc';
+      };
 
-    video.addEventListener('loadstart', (e) => {
-      console.log(e.type);
-    });
+      video.addEventListener('loadstart', (e) => {
+        console.log(e.type);
+      });
 
-    video.addEventListener('play', (e) => {
-      console.log(e.type);
-    });
+      video.addEventListener('play', (e) => {
+        console.log(e.type);
+      });
 
-    video.addEventListener('waiting', (e) => {
-      console.log(e.type);
-    });
+      video.addEventListener('waiting', (e) => {
+        console.log(e.type);
+      });
 
-    video.addEventListener('playing', (e) => {
-      console.log(e.type);
-    });
+      video.addEventListener('playing', (e) => {
+        console.log(e.type);
+      });
 
-    video.addEventListener('pause', (e) => {
-      console.log(e.type);
-    });
+      video.addEventListener('pause', (e) => {
+        console.log(e.type);
+      });
 
-    video.addEventListener('seeking', (e) => {
-      console.log(e.type);
-    });
+      video.addEventListener('seeking', (e) => {
+        console.log(e.type);
+      });
 
-    video.addEventListener('seeked', (e) => {
-      console.log(e.type);
-    });
+      video.addEventListener('seeked', (e) => {
+        console.log(e.type);
+      });
 
-    video.addEventListener('ended', (e) => {
-      console.log(e.type);
-    });
+      video.addEventListener('ended', (e) => {
+        console.log(e.type);
+      });
 
-    video.addEventListener('durationchange', (e) => {
-      console.log(e.type, video.duration);
-    });
+      video.addEventListener('durationchange', (e) => {
+        console.log(e.type, video.duration);
+      });
 
-    video.addEventListener('volumechange', (e) => {
-      console.log(e.type, video.volume);
-    });
+      video.addEventListener('volumechange', (e) => {
+        console.log(e.type, video.volume);
+      });
 
-    video.addEventListener('resize', (e) => {
-      console.log(e.type, video.videoWidth, video.videoHeight);
-    });
-    video.addEventListener('error', (e) => {
-      console.log(e);
-    });
-  </script>
+      video.addEventListener('resize', (e) => {
+        console.log(e.type, video.videoWidth, video.videoHeight);
+      });
 
-</body>
+      video.addEventListener('error', (e) => {
+        console.log(e.type, video.error);
+      });
+    </script>
+  </body>
 </html>

--- a/packages/youtube-video-element/youtube-video-element.js
+++ b/packages/youtube-video-element/youtube-video-element.js
@@ -82,6 +82,7 @@ class YoutubeVideoElement extends (globalThis.HTMLElement ?? class {}) {
   #seeking = false;
   #seekComplete;
   isLoaded = false;
+  #error = null;
 
   async load() {
     if (this.#loadRequested) return;
@@ -136,7 +137,11 @@ class YoutubeVideoElement extends (globalThis.HTMLElement ?? class {}) {
         },
         onError: (error) => {
           console.error(error);
-          this.dispatchEvent(new CustomEvent('error', { detail: error }));
+          this.#error = {
+            code: error.data,
+            message: `YouTube iframe player error #${error.data}; visit https://developers.google.com/youtube/iframe_api_reference#onError for the full error message.`
+          }
+          this.dispatchEvent(new Event('error'));
         },
       },
     });
@@ -277,6 +282,10 @@ class YoutubeVideoElement extends (globalThis.HTMLElement ?? class {}) {
   set src(val) {
     if (this.src == val) return;
     this.setAttribute('src', val);
+  }
+
+  get error() {
+    return this.#error;
   }
 
   /* onStateChange

--- a/packages/youtube-video-element/youtube-video-element.js
+++ b/packages/youtube-video-element/youtube-video-element.js
@@ -134,7 +134,10 @@ class YoutubeVideoElement extends (globalThis.HTMLElement ?? class {}) {
           this.isLoaded = true;
           this.loadComplete.resolve();
         },
-        onError: (error) => console.error(error),
+        onError: (error) => {
+          console.error(error);
+          this.dispatchEvent(new CustomEvent('error', { detail: error }));
+        },
       },
     });
 


### PR DESCRIPTION
Fixes #57 

## Added
* `dispatchEvent()` call to the errors for YouTube
* `addEventListener('error')` to display it in the console in the YouTube video element

The following screenshot displays how, given an issue with the YouTube video, the console will display the error with all the information
![image](https://github.com/user-attachments/assets/0cd1591b-a491-428f-9466-c2da5b734149)
