### PR TITLE
fix: YT config on React (SSR) + config types

### DIFF
--- a/examples/nextjs/app/youtube-video/page.tsx
+++ b/examples/nextjs/app/youtube-video/page.tsx
@@ -11,6 +11,9 @@ export default function Page() {
       <section>
         <YoutubeVideo
           className="video"
+          config={{
+            start: 20,
+          }}
           src="https://www.youtube.com/watch?v=uxsOYVWclA0"
           controls
           playsInline

--- a/packages/youtube-video-element/youtube-video-element.d.ts
+++ b/packages/youtube-video-element/youtube-video-element.d.ts
@@ -7,4 +7,20 @@ export default class CustomVideoElement extends HTMLVideoElement {
   ): void;
   connectedCallback(): void;
   disconnectedCallback(): void;
+  config: {
+    cc_lang_pref?: string;
+    cc_load_policy?: 1;
+    color?: 'red' | 'white';
+    disablekb?: 0 | 1;
+    enablejsapi?: 0 | 1;
+    end?: number;
+    fs?: 0 | 1;
+    hl?: string;
+    iv_load_policy?: 1 | 3;
+    origin?: string;
+    playlist?: string;
+    rel?: 0 | 1;
+    start?: number;
+    widget_referrer?: string;
+  }
 }


### PR DESCRIPTION
this fixes an issue where the YT video is loaded before React can set the config property on the client side.
the fix serializes the config in a data-config property on the iframe and when the first load happens it gets this config.