### PR TITLE
fix: Notify Video element the metadata is still loading

### DIFF
--- a/packages/hls-video-element/hls-video-element.js
+++ b/packages/hls-video-element/hls-video-element.js
@@ -125,16 +125,6 @@ const HlsVideoMixin = (superclass) => {
           this.#toggleHlsLoad
         );
 
-        this.nativeEl.addEventListener('loadstart', () => {
-          if (this.nativeEl.autoplay && this.nativeEl.paused) 
-            this.nativeEl.play();
-        
-          this.#setLoadingState(true);
-        });
-
-        this.nativeEl.addEventListener('loadedmetadata', () => {
-          this.#setLoadingState(false);
-        });
 
         this.#airplaySourceEl = document.createElement('source');
         this.#airplaySourceEl.setAttribute('type', 'application/x-mpegURL');
@@ -150,6 +140,12 @@ const HlsVideoMixin = (superclass) => {
         const levelIdMap = new WeakMap();
 
         this.api.on(Hls.Events.MANIFEST_PARSED, (event, data) => {
+          // If the video is set to autoplay, start playback.
+          if (this.nativeEl.autoplay && this.nativeEl.paused) {
+            this.nativeEl.play().catch((err) => {
+              console.warn('Autoplay failed:', err);
+            });
+          }
           removeAllMediaTracks();
 
           let videoTrack = this.videoTracks.getTrackById('main');
@@ -276,13 +272,6 @@ const HlsVideoMixin = (superclass) => {
         this.api?.startLoad();
       }
     };
-
-    #setLoadingState(isLoading) {
-      this.nativeEl?.dispatchEvent(new Event('waiting', { bubbles: true, composed: true }));
-      if (!isLoading) {
-        this.nativeEl?.dispatchEvent(new Event('canplay', { bubbles: true, composed: true }));
-      }
-    }
 
     // This is a pattern to update property values that are set before
     // the custom element is upgraded.

--- a/packages/hls-video-element/hls-video-element.js
+++ b/packages/hls-video-element/hls-video-element.js
@@ -125,7 +125,6 @@ const HlsVideoMixin = (superclass) => {
           this.#toggleHlsLoad
         );
 
-
         this.#airplaySourceEl = document.createElement('source');
         this.#airplaySourceEl.setAttribute('type', 'application/x-mpegURL');
         this.#airplaySourceEl.setAttribute('src', this.src);

--- a/packages/hls-video-element/hls-video-element.js
+++ b/packages/hls-video-element/hls-video-element.js
@@ -125,6 +125,17 @@ const HlsVideoMixin = (superclass) => {
           this.#toggleHlsLoad
         );
 
+        this.nativeEl.addEventListener('loadstart', () => {
+          if (this.nativeEl.autoplay && this.nativeEl.paused) 
+            this.nativeEl.play();
+        
+          this.#setLoadingState(true);
+        });
+
+        this.nativeEl.addEventListener('loadedmetadata', () => {
+          this.#setLoadingState(false);
+        });
+
         this.#airplaySourceEl = document.createElement('source');
         this.#airplaySourceEl.setAttribute('type', 'application/x-mpegURL');
         this.#airplaySourceEl.setAttribute('src', this.src);
@@ -265,6 +276,13 @@ const HlsVideoMixin = (superclass) => {
         this.api?.startLoad();
       }
     };
+
+    #setLoadingState(isLoading) {
+      this.nativeEl?.dispatchEvent(new Event('waiting', { bubbles: true, composed: true }));
+      if (!isLoading) {
+        this.nativeEl?.dispatchEvent(new Event('canplay', { bubbles: true, composed: true }));
+      }
+    }
 
     // This is a pattern to update property values that are set before
     // the custom element is upgraded.


### PR DESCRIPTION
This fixes [issue #1078](https://github.com/muxinc/media-chrome/issues/1078), where an **hls** element set to autoplay in Media Chrome shows a black screen while metadata is loading, instead of displaying the loading indicator as expected.

**Solution:**
Dispatch a waiting event on load, and a canplay event once metadata has loaded.