### PR TITLE
feat: Vimeo fullscreen & PiP via API to avoid Apple iframe restriction

### DIFF
--- a/packages/vimeo-video-element/vimeo-video-element.js
+++ b/packages/vimeo-video-element/vimeo-video-element.js
@@ -102,27 +102,19 @@ class VimeoVideoElement extends (globalThis.HTMLElement ?? class {}) {
   }
 
   requestFullscreen() {
-    if (this.api?.requestFullscreen instanceof Function) {
-      return this.api.requestFullscreen();
-    }
+    return this.api?.requestFullscreen?.();
   }
 
   exitFullscreen() {
-    if (this.api?.exitFullscreen instanceof Function) {
-      return this.api.exitFullscreen();
-    }
+    return this.api?.exitFullscreen?.();
   }
 
   requestPictureInPicture() {
-    if (this.api?.requestPictureInPicture instanceof Function) {
-      return this.api.requestPictureInPicture();
-    }
+    return this.api?.requestPictureInPicture?.();
   }
 
   exitPictureInPicture() {
-    if (this.api?.exitPictureInPicture instanceof Function) {
-      return this.api.exitPictureInPicture();
-    }
+    return this.api?.exitPictureInPicture?.();
   }
 
   get config() {

--- a/packages/vimeo-video-element/vimeo-video-element.js
+++ b/packages/vimeo-video-element/vimeo-video-element.js
@@ -282,6 +282,18 @@ class VimeoVideoElement extends (globalThis.HTMLElement ?? class {}) {
       this.dispatchEvent(new Event('resize'));
     });
 
+    this.requestFullscreen = () => {
+      if (this.api && typeof this.api.requestFullscreen === 'function') {
+        return this.api.requestFullscreen();
+      }
+    };
+    
+    this.requestPictureInPicture = () => {
+      if (this.api && typeof this.api.requestPictureInPicture === 'function') {
+        return this.api.requestPictureInPicture();
+      }
+    };
+    
     await this.loadComplete;
   }
 

--- a/packages/vimeo-video-element/vimeo-video-element.js
+++ b/packages/vimeo-video-element/vimeo-video-element.js
@@ -101,6 +101,30 @@ class VimeoVideoElement extends (globalThis.HTMLElement ?? class {}) {
     this.#upgradeProperty('config');
   }
 
+  requestFullscreen() {
+    if (this.api?.requestFullscreen instanceof Function) {
+      return this.api.requestFullscreen();
+    }
+  }
+
+  exitFullscreen() {
+    if (this.api?.exitFullscreen instanceof Function) {
+      return this.api.exitFullscreen();
+    }
+  }
+
+  requestPictureInPicture() {
+    if (this.api?.requestPictureInPicture instanceof Function) {
+      return this.api.requestPictureInPicture();
+    }
+  }
+
+  exitPictureInPicture() {
+    if (this.api?.exitPictureInPicture instanceof Function) {
+      return this.api.exitPictureInPicture();
+    }
+  }
+
   get config() {
     return this.#config;
   }
@@ -282,18 +306,6 @@ class VimeoVideoElement extends (globalThis.HTMLElement ?? class {}) {
       this.dispatchEvent(new Event('resize'));
     });
 
-    this.requestFullscreen = () => {
-      if (this.api && typeof this.api.requestFullscreen === 'function') {
-        return this.api.requestFullscreen();
-      }
-    };
-    
-    this.requestPictureInPicture = () => {
-      if (this.api && typeof this.api.requestPictureInPicture === 'function') {
-        return this.api.requestPictureInPicture();
-      }
-    };
-    
     await this.loadComplete;
   }
 


### PR DESCRIPTION
### Summary
This PR updates the Vimeo element to use Vimeo's official JS API for fullscreen and Picture-in-Picture (PiP), instead of relying on native iframe fullscreen events — which are blocked by Apple in nested iframe scenarios.

This allow the fullscreen using media-chrome with vimeo-element and closes [#119](https://github.com/muxinc/media-elements/issues/119)