### PR TITLE
Update error handling for youtube-video-element

### DIFF
--- a/packages/youtube-video-element/youtube-video-element.js
+++ b/packages/youtube-video-element/youtube-video-element.js
@@ -184,12 +184,11 @@ class YoutubeVideoElement extends (globalThis.HTMLElement ?? class {}) {
           this.loadComplete.resolve();
         },
         onError: (error) => {
-          console.error(error);
           this.#error = {
             code: error.data,
             message: `YouTube iframe player error #${error.data}; visit https://developers.google.com/youtube/iframe_api_reference#onError for the full error message.`
           }
-          this.dispatchEvent(new Event('error'));
+          this.dispatchEvent(new CustomEvent('error', {details: error}));
         },
       },
     });


### PR DESCRIPTION
This continues on the original issue https://github.com/muxinc/media-elements/issues/57 and the PR https://github.com/muxinc/media-elements/pull/78.

The original PR made sure the error event is dispatched (thank you!) but it does notinclude the actual error. This means you can't react accordingly.

So this PR includes the actual error and removes the console.error, so that consumers of this module can decide how to handle it.