### PR TITLE
Fix: Add share URLs to TikTok pattern matching

### DIFF
--- a/packages/tiktok-video-element/tiktok-video-element.js
+++ b/packages/tiktok-video-element/tiktok-video-element.js
@@ -1,7 +1,7 @@
 // https://developers.tiktok.com/doc/embed-player
 
 const EMBED_BASE = 'https://www.tiktok.com/player/v1';
-const MATCH_SRC = /tiktok\.com\/(?:@[^/]+\/video\/)?(\d+)(?:\/([\w-]+))?/;
+const MATCH_SRC = /tiktok\.com\/(?:(?:@[\w.]+)|share)\/video\/(\d+)(?:\/([\w-]+))?/;
 
 const PlayerState = { INIT: -1, ENDED: 0, PLAYING: 1, PAUSED: 2, BUFFERING: 3 };
 


### PR DESCRIPTION
TikTok supports two versions of URL's:

https://www.tiktok.com/@_luwes/video/7527476667770522893
and
https://www.tiktok.com/share/video/7527476667770522893

The second format redirects to the first format, but is still accessible as an embed src. This is useful since TikTok users may change usernames.

I have tested it in the example and it works fine. This needs another update to React-Player as well which I will make a PR for.