### PR TITLE
fix: Only handle messages from the corresponding iframe

### DIFF
--- a/packages/tiktok-video-element/tiktok-video-element.js
+++ b/packages/tiktok-video-element/tiktok-video-element.js
@@ -155,13 +155,6 @@ class TikTokVideoElement extends (globalThis.HTMLElement ?? class {}) {
     }
   }
 
-  connectedCallback() {
-    globalThis.addEventListener('message', this.#onMessage);
-  }
-
-  disconnectedCallback() {
-    globalThis.removeEventListener('message', this.#onMessage);
-  }
 
   get config() {
     return this.#config;


### PR DESCRIPTION
This PR improves message handling in the TikTok video component by ensuring that each instance only responds to messages emitted by its own embedded <iframe>. Solves [Issues 152](https://github.com/muxinc/media-elements/issues/152) Previously, all instances listened to the same global message events, causing duplicate event handling.