### PR TITLE
[vimeo] Fix: update MATCH_SRC to include vimeo/event/:id URLs.

### DIFF
--- a/packages/vimeo-video-element/vimeo-video-element.js
+++ b/packages/vimeo-video-element/vimeo-video-element.js
@@ -2,7 +2,7 @@
 import VimeoPlayerAPI from '@vimeo/player/dist/player.es.js';
 
 const EMBED_BASE = 'https://player.vimeo.com/video';
-const MATCH_SRC = /vimeo\.com\/(?:video\/)?(\d+)(?:\/([\w-]+))?/;
+const MATCH_SRC = /vimeo\.com\/(?:video\/|event\/)?(\d+)(?:\/([\w-]+))?/;
 
 function getTemplateHTML(attrs, props = {}) {
   const iframeAttrs = {


### PR DESCRIPTION
The media element was not matching valid `vimeo.com/event/:id` URLs, as reported here: https://github.com/cookpete/react-player/issues/1978