### PR TITLE
fix(castable-video): Fix stalled Google Cast playback of some HLS streams with .ts segments

### DIFF
--- a/packages/castable-video/castable-mixin.js
+++ b/packages/castable-video/castable-mixin.js
@@ -146,6 +146,9 @@ export const CastableMediaMixin = (superclass) =>
         if (isFragmentedMP4) {
           mediaInfo.hlsSegmentFormat = chrome.cast.media.HlsSegmentFormat.FMP4;
           mediaInfo.hlsVideoSegmentFormat = chrome.cast.media.HlsVideoSegmentFormat.FMP4;
+        } else if (segmentFormat?.includes('ts')) {
+          mediaInfo.hlsSegmentFormat = chrome.cast.media.HlsSegmentFormat.TS;
+          mediaInfo.hlsVideoSegmentFormat = chrome.cast.media.HlsVideoSegmentFormat.TS;
         }
       }
 


### PR DESCRIPTION
Similar to the #89, this explicitly sets `hlsSegmentFormat` and `hlsVideoSegmentFormat` to `chrome.cast.media.HlsSegmentFormat.TS` when a playing a HLS stream with `.ts` segment files.

This fixes stalled Google Cast playback of some HLS streams we've observed.