### PR TITLE
feat(vimeo): add TextTrack support using Vimeo API and add media-tracks integration

### DIFF
--- a/packages/media-tracks/src/global.ts
+++ b/packages/media-tracks/src/global.ts
@@ -2,6 +2,7 @@ import type { VideoTrack } from './video-track.js';
 import type { VideoTrackList } from './video-track-list.js';
 import type { AudioTrack } from './audio-track.js';
 import type { AudioTrackList } from './audio-track-list.js';
+import type { TextTrack } from './text-track.js';
 import type { VideoRenditionList } from './video-rendition-list.js';
 import type { AudioRenditionList } from './audio-rendition-list.js';
 
@@ -11,6 +12,8 @@ declare global {
     audioTracks: AudioTrackList;
     addVideoTrack(kind: string, label?: string, language?: string): VideoTrack;
     addAudioTrack(kind: string, label?: string, language?: string): AudioTrack;
+    addTextTrack(kind: string, label?: string, language?: string): TextTrack;
+    removeTextTrack(track: TextTrack): void;
     removeVideoTrack(track: VideoTrack): void;
     removeAudioTrack(track: AudioTrack): void;
     videoRenditions: VideoRenditionList;

--- a/packages/media-tracks/src/index.ts
+++ b/packages/media-tracks/src/index.ts
@@ -10,5 +10,8 @@ export { AudioTrackList } from './audio-track-list.js';
 export { AudioRendition } from './audio-rendition.js';
 export { AudioRenditionList } from './audio-rendition-list.js';
 
+export { TextTrack, TextTrackKind } from './text-track.js';
+export { TextTrackList, addTextTrack, removeTextTrack, modeChanged } from './text-track-list.js';
+
 export { TrackEvent } from './track-event.js';
 export { RenditionEvent } from './rendition-event.js';

--- a/packages/media-tracks/src/text-track-list.ts
+++ b/packages/media-tracks/src/text-track-list.ts
@@ -1,0 +1,140 @@
+import { TextTrack } from './text-track.js';
+import { TrackEvent } from './track-event.js';
+import { getPrivate } from './utils.js';
+
+export function addTextTrack(trackList: TextTrackList, track: TextTrack) {
+  if (typeof track !== 'object' || track === null) return;
+
+  const privateTrackList = getPrivate(trackList);
+  if (!privateTrackList.trackSet) {
+    privateTrackList.trackSet = new Set<TextTrack>();
+  }
+  const trackSet: Set<TextTrack> = privateTrackList.trackSet;
+  if (trackSet.has(track)) return;
+  trackSet.add(track);
+
+  const index = trackSet.size - 1;
+  if (!(index in TextTrackList.prototype)) {
+    Object.defineProperty(TextTrackList.prototype, index, {
+      get() {
+        return [...getPrivate(this).trackSet][index];
+      }
+    });
+  }
+
+  queueMicrotask(() => {
+    trackList.dispatchEvent(new TrackEvent('addtrack', { track }));
+  });
+}
+
+export function removeTextTrack(trackList: TextTrackList, track: TextTrack) {
+  if (typeof track !== 'object' || track === null) return;
+
+  const privateTrackList = getPrivate(trackList);
+  if (!privateTrackList.trackSet) {
+    privateTrackList.trackSet = new Set<TextTrack>();
+  }
+  const trackSet: Set<TextTrack> = privateTrackList.trackSet;
+  if (!trackSet.has(track)) return;
+  trackSet.delete(track);
+
+  queueMicrotask(() => {
+    trackList.dispatchEvent(new TrackEvent('removetrack', { track }));
+  });
+}
+  
+export function modeChanged(track: TextTrack) {
+  const trackList: TextTrackList | undefined = track._trackList;
+  if (!trackList || !track) return;
+
+  const privateTrackList = getPrivate(trackList);
+  if (!privateTrackList.trackSet) {
+    privateTrackList.trackSet = new Set<TextTrack>();
+  }
+
+  if (privateTrackList.changeRequested) return;
+  privateTrackList.changeRequested = true;
+
+  queueMicrotask(() => {
+    delete privateTrackList.changeRequested;
+    trackList.dispatchEvent(new Event('change'));
+  });
+}
+
+export class TextTrackList extends EventTarget {
+  [index: number]: TextTrack;
+  #addTrackCallback?: () => void;
+  #removeTrackCallback?: () => void;
+  #changeCallback?: () => void;
+
+  constructor() {
+    super();
+    getPrivate(this).trackSet = new Set();
+  }
+
+  get #tracks() {
+    return getPrivate(this).trackSet;
+  }
+
+  [Symbol.iterator]() {
+    return this.#tracks.values();
+  }
+
+  get length() {
+    return this.#tracks.size;
+  }
+
+  getTrackById(id: string): TextTrack | null {
+    return [...this.#tracks].find(track => track.id === id) ?? null;
+  }
+
+  get selectedIndex() {
+    return [...this.#tracks].findIndex(track => track.mode === 'showing');
+  }
+
+  get onaddtrack() {
+    return this.#addTrackCallback;
+  }
+
+  set onaddtrack(callback: ((event?: { track: TextTrack }) => void) | undefined) {
+    if (this.#addTrackCallback) {
+      this.removeEventListener('addtrack', this.#addTrackCallback);
+      this.#addTrackCallback = undefined;
+    }
+    if (typeof callback === 'function') {
+      this.#addTrackCallback = callback;
+      this.addEventListener('addtrack', (event) => callback?.(event as unknown as { track: TextTrack }));
+    }
+  }
+
+  get onremovetrack() {
+    return this.#removeTrackCallback;
+  }
+
+  set onremovetrack(callback: ((event?: { track: TextTrack }) => void) | undefined) {
+    if (this.#removeTrackCallback) {
+      this.removeEventListener('removetrack', this.#removeTrackCallback);
+      this.#removeTrackCallback = undefined;
+    }
+    if (typeof callback === 'function') {
+      this.#removeTrackCallback = callback;
+      this.addEventListener('removetrack',  (event) => callback?.(event as unknown as { track: TextTrack }));
+    }
+  }
+
+  get onchange() {
+    return this.#changeCallback;
+  }
+
+  set onchange(callback) {
+    if (this.#changeCallback) {
+      this.removeEventListener('change', this.#changeCallback);
+      this.#changeCallback = undefined;
+    }
+    if (typeof callback === 'function') {
+      this.#changeCallback = callback;
+      this.addEventListener('change', callback);
+    }
+  }
+}
+

--- a/packages/media-tracks/src/text-track.ts
+++ b/packages/media-tracks/src/text-track.ts
@@ -1,0 +1,33 @@
+import { modeChanged as modeChanged, TextTrackList } from './text-track-list.js';
+
+export const TextTrackKind = {
+  subtitles: 'subtitles',
+  captions: 'captions',
+  descriptions: 'descriptions',
+  chapters: 'chapters',
+  metadata: 'metadata',
+};
+
+export class TextTrack {
+  id?: string;
+  kind?: string;
+  label = '';
+  language = '';
+  sourceBuffer?: SourceBuffer;
+  #mode: 'disabled' | 'showing' | 'hidden' = 'disabled';
+  _trackList?: TextTrackList;
+
+  // new private property to store the parent TextTrackList
+
+  get mode(): 'disabled' | 'showing' | 'hidden' {
+    return this.#mode;
+  }
+
+  set mode(val: 'disabled' | 'showing' | 'hidden') {
+    console.log('Setting mode from', this.#mode, 'to', val);
+    if (this.#mode === val) return;
+    this.#mode = val;
+
+    modeChanged(this);
+  }
+}

--- a/packages/media-tracks/src/track-event.ts
+++ b/packages/media-tracks/src/track-event.ts
@@ -1,10 +1,11 @@
 import type { AudioTrack } from './audio-track.js';
+import { TextTrack } from './text-track.js';
 import type { VideoTrack } from './video-track.js';
 
 export class TrackEvent extends Event {
-  track: VideoTrack | AudioTrack;
+  track: VideoTrack | AudioTrack | TextTrack;
 
-  constructor(type: string, init: Record<string, VideoTrack | AudioTrack>) {
+  constructor(type: string, init: Record<string, VideoTrack | AudioTrack | TextTrack>) {
     super(type);
     this.track = init.track;
   }

--- a/packages/vimeo-video-element/index.html
+++ b/packages/vimeo-video-element/index.html
@@ -21,11 +21,14 @@
   {
     "imports": {
       "@vimeo/player/": "https://cdn.jsdelivr.net/npm/@vimeo/player/"
+      ,"media-tracks": "../media-tracks/dist/index.js"
     }
   }
 </script>
+<script type="module" src="../media-tracks/dist/index.js"></script>
 <script type="module" src="./vimeo-video-element.js"></script>
 <script type="module" src="https://cdn.jsdelivr.net/npm/media-chrome/+esm"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/media-chrome/dist/menu/+esm"></script>
 
 <h1>&lt;vimeo-video&gt;</h1>
 <br>
@@ -50,7 +53,7 @@
   };
 
   loadbtn.onclick = () => {
-    video.src = 'https://vimeo.com/638371504';
+    video.src = 'https://vimeo.com/1093837607';
   }
 
   video.addEventListener('loadstart', (e) => {
@@ -109,6 +112,7 @@
     muted
     autopause
   ></vimeo-video>
+  <media-captions-menu hidden anchor="auto"></media-captions-menu>
   <media-control-bar>
     <media-play-button></media-play-button>
     <media-seek-backward-button seek-offset="15"></media-seek-backward-button>
@@ -117,6 +121,7 @@
     <media-volume-range></media-volume-range>
     <media-time-range></media-time-range>
     <media-time-display show-duration remaining></media-time-display>
+    <media-captions-menu-button></media-captions-menu-button>
     <media-playback-rate-button></media-playback-rate-button>
     <media-pip-button></media-pip-button>
     <media-fullscreen-button></media-fullscreen-button>

--- a/packages/vimeo-video-element/package.json
+++ b/packages/vimeo-video-element/package.json
@@ -52,7 +52,8 @@
     "build": "run-s build:*"
   },
   "dependencies": {
-    "@vimeo/player": "2.29.0"
+    "@vimeo/player": "2.29.0",
+    "media-tracks": "^0.3.3"
   },
   "devDependencies": {
     "build-react-wrapper": "^0.2.2",

--- a/packages/vimeo-video-element/test/index.html
+++ b/packages/vimeo-video-element/test/index.html
@@ -4,6 +4,7 @@
   {
     "imports": {
       "zora": "https://cdn.jsdelivr.net/npm/zora/dist/index.js",
+      "media-tracks": "https://cdn.jsdelivr.net/npm/media-tracks@0.3/+esm",
       "@vimeo/player/": "https://cdn.jsdelivr.net/npm/@vimeo/player/"
     }
   }

--- a/packages/vimeo-video-element/vimeo-video-element.js
+++ b/packages/vimeo-video-element/vimeo-video-element.js
@@ -1,6 +1,6 @@
 // https://github.com/vimeo/player.js
 import VimeoPlayerAPI from '@vimeo/player/dist/player.es.js';
-
+import { TextTrack, TextTrackList, addTextTrack } from 'media-tracks';
 const EMBED_BASE = 'https://player.vimeo.com/video';
 const MATCH_SRC = /vimeo\.com\/(?:video\/)?(\d+)(?:\/([\w-]+))?/;
 
@@ -216,6 +216,31 @@ class VimeoVideoElement extends (globalThis.HTMLElement ?? class {}) {
     }
 
     this.api = new VimeoPlayerAPI(iframe);
+
+    this.textTracks = new TextTrackList();
+
+    this.api.getTextTracks().then((vimeoTracks) => {
+      vimeoTracks.forEach((t) => {
+        const track = new TextTrack();
+        track.kind = t.kind;
+        track.label = t.label;
+        track.language = t.language;
+        track.mode = t.mode || 'disabled';
+        track._trackList = this.textTracks;
+
+        addTextTrack(this.textTracks, track);
+      });
+    });
+
+    this.textTracks.addEventListener('change', () => {
+      const active = Array.from(this.textTracks).find((t) => t.mode === 'showing');
+      if (active) {
+        this.api.enableTextTrack(active.language, active.kind);
+      } else {
+        this.api.disableTextTrack();
+      }
+    });
+    
     const onceLoaded = () => {
       this.api.off('loaded', onceLoaded);
       onLoaded();

--- a/packages/youtube-video-element/index.html
+++ b/packages/youtube-video-element/index.html
@@ -39,7 +39,7 @@
   <media-controller>
     <youtube-video
       id="yt2"
-      src="https://www.youtube.com/watch?v=H3KSKS3TTbc"
+      src="https://www.youtube.com/watch?v=rubNgGj3pYo"
       slot="media"
       autopause
     ></youtube-video>


### PR DESCRIPTION
This reolve [160](https://github.com/muxinc/media-elements/issues/160) by adding support for text tracks in the <vimeo-video> element by integrating Vimeo’s API and extending media-tracks to handle a new track kind.

Key changes
	•	Fetches subtitle/caption track metadata from the Vimeo API.
	•	Creates and attaches TextTrack objects for each available track.
	•	Keeps TextTrackList in sync with the player state.
	•	Dispatches standard addtrack / removetrack events for listeners.
	•	Introduces a new internal track type to represent text tracks.
	•	Implements add/remove handling consistent with existing audio/video track logic.
	
For Test can use this **vimeo** video https://vimeo.com/1093837607