### PR TITLE
fix: onVolumeChange returns stale value

### DIFF
--- a/packages/twitch-video-element/twitch-video-element.js
+++ b/packages/twitch-video-element/twitch-video-element.js
@@ -356,6 +356,12 @@ class TwitchVideoElement extends (globalThis.HTMLElement ?? class {}) {
       }
 
       if (oldVolume !== this.#playerState.volume || oldMuted !== this.#playerState.muted) {
+        if (this.#playerState.volume !== undefined) {
+          this.#volume = this.#playerState.volume;
+        }
+        if (this.#playerState.muted !== undefined) {
+          this.#muted = this.#playerState.muted;
+        }
         this.dispatchEvent(new Event('volumechange'));
       }
 


### PR DESCRIPTION
This PR closes [#173 ](https://github.com/muxinc/media-elements/issues/173)

The #volume (internal class property) was not being updated when the Twitch player's volume changes