### PR TITLE
Add support for MPD Tiles of thumbnail images

### DIFF
--- a/packages/dash-video-element/dash-video-element.js
+++ b/packages/dash-video-element/dash-video-element.js
@@ -33,11 +33,11 @@ class DashVideoElement extends MediaTracksMixin(CustomVideoElement) {
       const tduration = representation.segmentDuration;
       for (let thIndex = 0; thIndex < totalThumbnails; thIndex++) {
         const startTime = calculateThumbnailStartTime({
-          thIndex: thIndex, 
-          thduration: thumbnailDuration, 
-          ttiles: totalThumbnails, 
-          tduration: tduration, 
-          startNumber: startNumber, 
+          thIndex: thIndex,
+          thduration: thumbnailDuration,
+          ttiles: totalThumbnails,
+          tduration: tduration,
+          startNumber: startNumber,
           pto: pto
         })
         const endTime = startTime + thumbnailDuration;
@@ -70,7 +70,7 @@ class DashVideoElement extends MediaTracksMixin(CustomVideoElement) {
       this.nativeEl.appendChild(track);
       const vttUrl = cuesToVttBlobUrl(cues);
       track.src = vttUrl;
-  
+
       track.dispatchEvent(new Event('change'));
     }
   }
@@ -121,8 +121,8 @@ class DashVideoElement extends MediaTracksMixin(CustomVideoElement) {
       if (!this.api.isDynamic()) {
         const imageReps = this.api.getRepresentationsByType("image")
         imageReps.forEach(async (rep, idx) => {
-          // One MPD could provide alternative thumbnailt racks, for now we only support the first one.
-          if (idx > 0) return; 
+          // One MPD could provide alternative thumbnail tracks, for now we only support the first one.
+          if (idx > 0) return;
 
           this._initThumbnails(rep);
         })
@@ -145,14 +145,17 @@ function calculateThumbnailTimes(representation) {
   const [htiles, vtiles] = essentialProp.value.split("x").map(Number);
   const ttiles = htiles * vtiles;
 
-  const duration = representation.segmentDuration
+  const periodDuration = representation.adaptation?.period?.duration || null;
+  const tileDuration = representation.segmentDuration;
   const timescale = representation.timescale || 1;
   /** Duration of a thumbnail tile */
-  const tduration = duration / timescale;
+  const tduration = tileDuration / timescale;
   /** Duration of an individual thumbnail within a tile */
   const thduration = tduration / ttiles;
-  /** How many thumbnails in a tile */
-  const totalThumbnails = Math.ceil(duration / thduration);
+  /** How many thumbnails in a period. 
+   * The guideline does not specify what to do if we don't have the period duration value
+   * so we default to however many we have in this tile */
+  const totalThumbnails = (periodDuration != null) ? Math.ceil(periodDuration / thduration) : Math.ceil(tileDuration / thduration)
 
   return { totalThumbnails: totalThumbnails, thumbnailDuration: thduration };
 }


### PR DESCRIPTION
resolves https://github.com/muxinc/media-chrome/issues/1211

Added support for tiles of thumbnail images provided via MPD as specified in [Guidelines for Implementation:
DASH-IF Interoperability Points](https://dashif.org/docs/DASH-IF-IOP-v4.3.pdf) section "6.2.6. Tiles of thumbnail images".

The changes include checking for image representations, creating a WebVTT Blob file, and creating the thumbnail `<track/>` element inside `<dash-video/>` with it's source pointing to the file. This is done only on stream initialization. We don't update an existing thumbnail `<track/>` element so we don't overwrite whatever is set on the HTML.

This PR currently does not include livestream support since it doesn't work as expected (see comment below).

Some example MPDs to test this:
- vod single track - https://dash.akamaized.net/akamai/bbb_30fps/bbb_with_tiled_thumbnails.mpd
- vod multi track - https://dash.akamaized.net/akamai/bbb_30fps/bbb_with_multiple_tiled_thumbnails.mpd
- live (not supported) - https://livesim2.dashif.org/livesim2/testpic_2s/Manifest_thumbs.mpd 

There's some more in https://reference.dashif.org/dash.js/nightly/samples/dash-if-reference-player/index.html

<img width="657" height="362" alt="Screenshot 2025-10-16 at 12 58 12 PM" src="https://github.com/user-attachments/assets/d02678fe-f90a-4857-8c03-e3a99c08dbdc" />
