### PR TITLE
Fix/volumechange youtube

### DIFF
--- a/packages/youtube-video-element/youtube-video-element.js
+++ b/packages/youtube-video-element/youtube-video-element.js
@@ -327,7 +327,6 @@ class YoutubeVideoElement extends (globalThis.HTMLElement ?? class {}) {
       case 'loop':
       case 'playsinline': {
         this.load();
-        break;
       }
     }
   }


### PR DESCRIPTION
This PR closes #178 

Stores the initial volume in a private property and applies it on onReady so the volume getter returns the correct value before the YouTube player loads.