### PR TITLE
fix: Upgrade ce-la-react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2328,9 +2328,9 @@
       "link": true
     },
     "node_modules/ce-la-react": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ce-la-react/-/ce-la-react-0.3.1.tgz",
-      "integrity": "sha512-g0YwpZDPIwTwFumGTzNHcgJA6VhFfFCJkSNdUdC04br2UfU+56JDrJrJva3FZ7MToB4NDHAFBiPE/PZdNl1mQA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ce-la-react/-/ce-la-react-0.3.2.tgz",
+      "integrity": "sha512-QJ6k4lOD/btI08xG8jBPxRCGXvCnusGGkTsiXk0u3NqUu/W+BXRnFD4PYjwtqh8AWmGa5LDbGk0fLQsqr0nSMA==",
       "license": "BSD-3-Clause",
       "peerDependencies": {
         "react": ">=17.0.0"
@@ -7690,7 +7690,7 @@
     "scripts/build-react-wrapper": {
       "version": "0.2.3",
       "dependencies": {
-        "ce-la-react": "^0.3.1",
+        "ce-la-react": "^0.3.2",
         "tsup": "^8.3.5"
       },
       "bin": {

--- a/scripts/build-react-wrapper/package.json
+++ b/scripts/build-react-wrapper/package.json
@@ -8,7 +8,7 @@
     "build-react-wrapper": "./build.js"
   },
   "dependencies": {
-    "ce-la-react": "^0.3.1",
+    "ce-la-react": "^0.3.2",
     "tsup": "^8.3.5"
   }
 }


### PR DESCRIPTION
Relates to https://github.com/muxinc/next-video/issues/397 and https://github.com/muxinc/ce-la-react/pull/7

Upgrades ce-la-react to prevent missing key warning when using custom components on SSR.