### PR TITLE
fix: Update YouTube `cc_load_policy` config type to allow 0 or 1

### DIFF
--- a/packages/youtube-video-element/youtube-video-element.d.ts
+++ b/packages/youtube-video-element/youtube-video-element.d.ts
@@ -9,7 +9,7 @@ export default class CustomVideoElement extends HTMLVideoElement {
   disconnectedCallback(): void;
   config: {
     cc_lang_pref?: string;
-    cc_load_policy?: 1;
+    cc_load_policy?: 0 | 1;
     color?: 'red' | 'white';
     disablekb?: 0 | 1;
     enablejsapi?: 0 | 1;


### PR DESCRIPTION
This parameter is defaulted to `1` [by the video element](https://github.com/muxinc/media-elements/blob/5c518f1bb6cf111b737caa2415293de0abf7b1c8/packages/youtube-video-element/youtube-video-element.js#L70), but the types here don't allow setting it to `0` to turn it back off.

`0` being a valid option isn't really documented by YouTube, so I'm not sure if this is the right approach. The most I could find is from [this developer sample](https://developers.google.com/youtube/youtube_player_demo) that indicates for the options that are checkboxes, `0` is the unchecked state and `1` is the checked state.
<img width="624" height="315" alt="image" src="https://github.com/user-attachments/assets/36e53000-6d14-441d-b52a-c0c9d04ce85f" />

An alternative change could be to remove the defaulting `cc_load_policy` to `1` in the video element, which would allow the `cc_load_policy` parameter being `undefined` to fallback to the expected default behaviour. I'm open to your thoughts!