### PR TITLE
fix: support for unlisted Vimeo videos

### DIFF
--- a/packages/vimeo-video-element/vimeo-video-element.js
+++ b/packages/vimeo-video-element/vimeo-video-element.js
@@ -63,7 +63,7 @@ function serializeIframeUrl(attrs, props) {
   };
 
   // Handle events
-  if (urlType === 'event') {
+  if (urlType === 'event/') {
     return `${EMBED_EVENT_BASE}/${srcId}/embed?${serialize(params)}`;
   }
 


### PR DESCRIPTION
Fixes #191 

Added URL parsing to cover `h` param use case