### PR TITLE
feat: add support for YouTube `t` param to set video start time

### DIFF
--- a/packages/youtube-video-element/test/test.js
+++ b/packages/youtube-video-element/test/test.js
@@ -145,6 +145,111 @@ test('playlist', async function (t) {
   t.ok(playlist.duration > 0, `has a duration of ${playlist.duration}`);
 });
 
+test('t parameter - basic seconds', async function (t) {
+  const video = await fixture(`<youtube-video
+    src="https://www.youtube.com/watch?v=H3KSKS3TTbc&t=171"
+    muted
+  ></youtube-video>`);
+  
+  await video.loadComplete;
+  
+  const iframe = video.shadowRoot.querySelector('iframe');
+  const iframeUrl = new URL(iframe.src);
+  const startParam = iframeUrl.searchParams.get('start');
+  
+  t.equal(startParam, '171', 'start parameter is set to 171 seconds');
+});
+
+test('t parameter - youtu.be format', async function (t) {
+  const video = await fixture(`<youtube-video
+    src="https://youtu.be/H3KSKS3TTbc?t=171"
+    muted
+  ></youtube-video>`);
+  
+  await video.loadComplete;
+  
+  const iframe = video.shadowRoot.querySelector('iframe');
+  const iframeUrl = new URL(iframe.src);
+  const startParam = iframeUrl.searchParams.get('start');
+  
+  t.equal(startParam, '171', 'start parameter is set to 171 seconds from youtu.be URL');
+});
+
+test('t parameter - with seconds suffix', async function (t) {
+  const video = await fixture(`<youtube-video
+    src="https://www.youtube.com/watch?v=H3KSKS3TTbc&t=171s"
+    muted
+  ></youtube-video>`);
+  
+  await video.loadComplete;
+  
+  const iframe = video.shadowRoot.querySelector('iframe');
+  const iframeUrl = new URL(iframe.src);
+  const startParam = iframeUrl.searchParams.get('start');
+  
+  t.equal(startParam, '171', 'start parameter is set to 171 seconds from t=171s');
+});
+
+test('t parameter - minutes and seconds', async function (t) {
+  const video = await fixture(`<youtube-video
+    src="https://www.youtube.com/watch?v=H3KSKS3TTbc&t=2m51s"
+    muted
+  ></youtube-video>`);
+  
+  await video.loadComplete;
+  
+  const iframe = video.shadowRoot.querySelector('iframe');
+  const iframeUrl = new URL(iframe.src);
+  const startParam = iframeUrl.searchParams.get('start');
+  
+  t.equal(startParam, '171', 'start parameter is set to 171 seconds from t=2m51s (2*60 + 51)');
+});
+
+test('t parameter - minutes only', async function (t) {
+  const video = await fixture(`<youtube-video
+    src="https://www.youtube.com/watch?v=H3KSKS3TTbc&t=3m"
+    muted
+  ></youtube-video>`);
+  
+  await video.loadComplete;
+  
+  const iframe = video.shadowRoot.querySelector('iframe');
+  const iframeUrl = new URL(iframe.src);
+  const startParam = iframeUrl.searchParams.get('start');
+  
+  t.equal(startParam, '180', 'start parameter is set to 180 seconds from t=3m (3*60)');
+});
+
+test('t parameter - no t parameter', async function (t) {
+  const video = await fixture(`<youtube-video
+    src="https://www.youtube.com/watch?v=H3KSKS3TTbc"
+    muted
+  ></youtube-video>`);
+  
+  await video.loadComplete;
+  
+  const iframe = video.shadowRoot.querySelector('iframe');
+  const iframeUrl = new URL(iframe.src);
+  const startParam = iframeUrl.searchParams.get('start');
+  
+  t.equal(startParam, null, 'start parameter is not set when t parameter is absent');
+});
+
+test('t parameter - case insensitive', async function (t) {
+  const video = await fixture(`<youtube-video
+    src="https://www.youtube.com/watch?v=H3KSKS3TTbc&T=171"
+    muted
+  ></youtube-video>`);
+  
+  await video.loadComplete;
+  
+  const iframe = video.shadowRoot.querySelector('iframe');
+  const iframeUrl = new URL(iframe.src);
+  const startParam = iframeUrl.searchParams.get('start');
+  
+  t.equal(startParam, '171', 'start parameter is set from uppercase T parameter');
+});
+
 function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/youtube-video-element/youtube-video-element.js
+++ b/packages/youtube-video-element/youtube-video-element.js
@@ -10,6 +10,40 @@ const VIDEO_MATCH_SRC =
 const PLAYLIST_MATCH_SRC =
   /(?:youtu\.be\/|youtube(?:-nocookie)?\.com\/.*?[?&]list=)([\w_-]+)/;
 
+/**
+ * Parses the `t` parameter from a YouTube URL and converts it to seconds.
+ * Supports formats like: t=171, t=171s, t=2m51s, t=2m
+ * @param {string} url - The YouTube URL
+ * @returns {number|undefined} - The start time in seconds, or undefined if not found
+ */
+function parseStartTime(url) {
+  if (!url) return;
+  
+  // Match t parameter: t=171, t=171s, t=2m51s, t=2m, etc.
+  const tMatch = url.match(/[?&]t=([\dms]+)/i);
+  if (!tMatch) return;
+  
+  const tValue = tMatch[1].toLowerCase();
+  let totalSeconds = 0;
+  let hasValue = false;
+  
+  // Parse minutes (e.g., "2m" or "2m51s")
+  const minutesMatch = tValue.match(/(\d+)m/);
+  if (minutesMatch) {
+    totalSeconds += parseInt(minutesMatch[1], 10) * 60;
+    hasValue = true;
+  }
+  
+  // Parse seconds (e.g., "171s" or "51s" or just "171")
+  const secondsMatch = tValue.match(/(\d+)s?$/);
+  if (secondsMatch) {
+    totalSeconds += parseInt(secondsMatch[1], 10);
+    hasValue = true;
+  }
+  
+  return hasValue ? totalSeconds : undefined;
+}
+
 function getTemplateHTML(attrs, props = {}) {
 
   const iframeAttrs = {
@@ -72,6 +106,7 @@ function serializeIframeUrl(attrs, props) {
     rel: 0,
     iv_load_policy: 3,
     modestbranding: 1,
+    start: parseStartTime(attrs.src),
     ...props.config,
   };
 


### PR DESCRIPTION
This PR adds support for parsing the `t` parameter from YouTube URLs and converting it to the `start` parameter in the iframe embed URL, allowing videos to start at a specific timestamp.

## Changes

- Added `parseStartTime()` function to parse the `t` parameter from YouTube URLs
- Updated `serializeIframeUrl()` to include the `start` parameter when `t` is present in the source URL
- Supports multiple time formats: `t=171`, `t=171s`, `t=2m51s`, `t=2m`
- Case-insensitive parsing (works with both `t=` and `T=`)

## Example

```html
<youtube-video src="https://youtu.be/6kHu2tTS3qA?t=171"></youtube-video>
```

This will generate an iframe with `start=171` in the embed URL, causing the video to start at 171 seconds.

## Testing

Added 7 new test cases covering:
- Basic seconds format (`t=171`)
- `youtu.be` URL format
- Seconds with suffix (`t=171s`)
- Minutes and seconds (`t=2m51s`)
- Minutes only (`t=3m`)
- Absence of `t` parameter
- Case insensitivity (`T=171`)

All tests verify that the `start` parameter is correctly added to the iframe embed URL.

