### PR TITLE
Support YouTube cc_load_policy 0 value to disable closed captions

### DIFF
--- a/packages/youtube-video-element/youtube-video-element.d.ts
+++ b/packages/youtube-video-element/youtube-video-element.d.ts
@@ -9,7 +9,7 @@ export default class CustomVideoElement extends HTMLVideoElement {
   disconnectedCallback(): void;
   config: {
     cc_lang_pref?: string;
-    cc_load_policy?: 1;
+    cc_load_policy?: 0 | 1;
     color?: 'red' | 'white';
     disablekb?: 0 | 1;
     enablejsapi?: 0 | 1;


### PR DESCRIPTION
Adds the typing for `cc_load_policy` `0` to the config which disables closed captions on YouTube videos.