### PR TITLE
fix: support both path and query string formats for unlisted video hash

### DIFF
--- a/packages/vimeo-video-element/vimeo-video-element.js
+++ b/packages/vimeo-video-element/vimeo-video-element.js
@@ -45,9 +45,9 @@ function serializeIframeUrl(attrs, props) {
   let url = new URL(attrs.src);
 
   const matches = attrs.src.match(MATCH_SRC);
-  const urlType = matches && matches[1]; // 'video/' or 'event/' or undefined
-  const srcId = matches && matches[2];
-  const hParam = url.searchParams.get("h") || undefined;
+  const urlType = matches?.[1]; // 'video/' or 'event/' or undefined
+  const srcId = matches?.[2];
+  const hParam = url.searchParams.get("h") || matches?.[3];
   const params = {
     // ?controls=true is enabled by default in the iframe
     controls: attrs.controls === '' ? null : 0,


### PR DESCRIPTION
PR #195 changed `h` parameter extraction to only use query string format, breaking support for path format URLs like `vimeo.com/123/abc123`.

This fix supports both:
- Path format: `vimeo.com/123/abc123`
- Query format: `vimeo.com/123?h=abc123`

Fixes regression from #195