### PR TITLE
Add config support to wistia-video-element

### DIFF
--- a/examples/nextjs/app/wistia-video/page.tsx
+++ b/examples/nextjs/app/wistia-video/page.tsx
@@ -8,16 +8,14 @@ export const metadata: Metadata = {
 
 export default function Page() {
   return (
-    <>
-      <section>
-        <Player
-          as={WistiaVideo}
-          src="https://wesleyluyten.wistia.com/medias/oifkgmxnkb"
-          config={{
-            playerColor: '#f5f6f7',
-          }}
-        />
-      </section>
-    </>
+    <section>
+      <Player
+        as={WistiaVideo}
+        src="https://wesleyluyten.wistia.com/medias/oifkgmxnkb"
+        config={{
+          playerColor: 'AFE5A4',
+        }}
+      />
+    </section>
   );
 }

--- a/examples/nextjs/app/wistia-video/page.tsx
+++ b/examples/nextjs/app/wistia-video/page.tsx
@@ -13,6 +13,9 @@ export default function Page() {
         <Player
           as={WistiaVideo}
           src="https://wesleyluyten.wistia.com/medias/oifkgmxnkb"
+          config={{
+            playerColor: '#f5f6f7',
+          }}
         />
       </section>
     </>

--- a/packages/wistia-video-element/test/test.js
+++ b/packages/wistia-video-element/test/test.js
@@ -61,7 +61,7 @@ test('load promise', async function (t) {
   await video.loadComplete;
 
   t.ok(
-    loadComplete != video.loadComplete,
+    loadComplete !== video.loadComplete,
     'creates a new promise after new src'
   );
 
@@ -84,6 +84,52 @@ test('play promise', async function (t) {
     console.warn(error);
   }
   t.ok(!video.paused, 'is playing after video.play()');
+});
+
+test('passes config into Wistia options', async function (t) {
+  const previousWistia = globalThis.Wistia;
+  const previousWq = globalThis._wq;
+
+  try {
+    globalThis.Wistia = {};
+
+    const fakeApi = {
+      elem: () => document.createElement('video'),
+      duration: () => 0,
+      play: () => {},
+      bigPlayButtonEnabled: () => {},
+      releaseChromeless: () => {},
+      requestChromeless: () => {},
+    };
+
+    let pushed;
+    globalThis._wq = {
+      push: (payload) => {
+        pushed = payload;
+        payload.onReady(fakeApi);
+      },
+    };
+
+    const video = await fixture(`<wistia-video controls muted></wistia-video>`);
+
+    // Ensure user config takes precedence over element-derived defaults.
+    video.config = {
+      chromeless: true,
+      playButton: false,
+      playerColor: 'ff0000',
+    };
+
+    video.src = 'https://wesleyluyten.wistia.com/medias/oifkgmxnkb';
+    await video.loadComplete;
+
+    t.ok(pushed?.options, 'push payload includes options');
+    t.equal(pushed.options.chromeless, true, 'config overrides default chromeless');
+    t.equal(pushed.options.playButton, false, 'config overrides default playButton');
+    t.equal(pushed.options.playerColor, 'ff0000', 'config is forwarded into options');
+  } finally {
+    globalThis.Wistia = previousWistia;
+    globalThis._wq = previousWq;
+  }
 });
 
 function delay(ms) {

--- a/packages/wistia-video-element/wistia-video-element.d.ts
+++ b/packages/wistia-video-element/wistia-video-element.d.ts
@@ -1,10 +1,55 @@
+export type WistiaPluginConfig = Record<string, unknown>;
+
+export type WistiaEmbedOptions = {
+  autoPlay?: boolean;
+  controlsVisibleOnLoad?: boolean;
+  copyLinkAndThumbnailEnabled?: boolean;
+  doNotTrack?: boolean;
+  email?: string;
+  endVideoBehavior?: 'default' | 'reset' | 'loop';
+  fakeFullscreen?: boolean;
+  fitStrategy?: 'contain' | 'cover' | 'fill' | 'none';
+  fullscreenButton?: boolean;
+  muted?: boolean;
+  playbackRateControl?: boolean;
+  playbar?: boolean;
+  playButton?: boolean;
+  playerColor?: string;
+  playlistLinks?: boolean;
+  playlistLoop?: boolean;
+  playsinline?: boolean;
+  playPauseNotifier?: boolean;
+  playSuspendedOffScreen?: boolean;
+  preload?: 'metadata' | 'auto' | 'none' | boolean;
+  qualityControl?: boolean;
+  qualityMax?: 224 | 360 | 540 | 720 | 1080 | 3840;
+  qualityMin?: 224 | 360 | 540 | 720 | 1080 | 3840;
+  resumable?: boolean | 'auto';
+  seo?: boolean;
+  settingsControl?: boolean;
+  silentAutoPlay?: boolean | 'allow';
+  smallPlayButton?: boolean;
+  stillUrl?: string;
+  time?: number | string;
+  thumbnailAltText?: string;
+  videoFoam?:
+    | boolean
+    | {
+        minWidth?: number;
+        maxWidth?: number;
+        minHeight?: number;
+        maxHeight?: number;
+      };
+  volume?: number;
+  volumeControl?: boolean;
+  wmode?: string;
+  plugin?: WistiaPluginConfig;
+};
+
 export default class CustomVideoElement extends HTMLVideoElement {
   static readonly observedAttributes: string[];
-  attributeChangedCallback(
-    attrName: string,
-    oldValue?: string | null,
-    newValue?: string | null
-  ): void;
+  attributeChangedCallback(attrName: string, oldValue?: string | null, newValue?: string | null): void;
   connectedCallback(): void;
   disconnectedCallback(): void;
+  config: WistiaEmbedOptions | null;
 }

--- a/packages/wistia-video-element/wistia-video-element.d.ts
+++ b/packages/wistia-video-element/wistia-video-element.d.ts
@@ -2,6 +2,7 @@ export type WistiaPluginConfig = Record<string, unknown>;
 
 export type WistiaEmbedOptions = {
   autoPlay?: boolean;
+  chromeless?: boolean;
   controlsVisibleOnLoad?: boolean;
   copyLinkAndThumbnailEnabled?: boolean;
   doNotTrack?: boolean;
@@ -11,6 +12,7 @@ export type WistiaEmbedOptions = {
   fitStrategy?: 'contain' | 'cover' | 'fill' | 'none';
   fullscreenButton?: boolean;
   muted?: boolean;
+  keyMoments?: boolean;
   playbackRateControl?: boolean;
   playbar?: boolean;
   playButton?: boolean;

--- a/packages/wistia-video-element/wistia-video-element.js
+++ b/packages/wistia-video-element/wistia-video-element.js
@@ -28,9 +28,37 @@ if (templateShadowDOM) {
   `;
 }
 
+function upgradeProperty(el, prop) {
+  // This is a pattern to update property values that are set before
+  // the custom element is upgraded.
+  // https://web.dev/custom-elements-best-practices/#make-properties-lazy
+  if (Object.hasOwn(el, prop)) {
+    const value = el[prop];
+    // Delete the set property from this instance.
+    delete el[prop];
+    // Set the value again via the (prototype) setter on this class.
+    el[prop] = value;
+  }
+}
+
 class WistiaVideoElement extends SuperVideoElement {
   static template = templateShadowDOM;
   static skipAttributes = ['src'];
+
+  #config = null;
+
+  constructor() {
+    super();
+    upgradeProperty(this, 'config');
+  }
+
+  get config() {
+    return this.#config;
+  }
+
+  set config(value) {
+    this.#config = value;
+  }
 
   get nativeEl() {
     return this.api?.elem() ?? this.querySelector('video');
@@ -58,6 +86,7 @@ class WistiaVideoElement extends SuperVideoElement {
       chromeless: !this.controls,
       playButton: this.controls,
       muted: this.defaultMuted,
+      ...(this.#config ?? {}),
     };
 
     // Sadly the setup/render will not work in the shadow DOM.
@@ -119,14 +148,16 @@ async function loadScript(src, globalName) {
   if (!globalName) return import(/* webpackIgnore: true */ src);
   if (loadScriptCache[src]) return loadScriptCache[src];
   if (self[globalName]) return self[globalName];
-  return (loadScriptCache[src] = new Promise((resolve, reject) => {
+  const promise = new Promise((resolve, reject) => {
     const script = document.createElement('script');
     script.defer = true;
     script.src = src;
     script.onload = () => resolve(self[globalName]);
     script.onerror = reject;
     document.head.append(script);
-  }));
+  });
+  loadScriptCache[src] = promise;
+  return promise;
 }
 
 let idCounter = 0;

--- a/packages/wistia-video-element/wistia-video-element.js
+++ b/packages/wistia-video-element/wistia-video-element.js
@@ -80,9 +80,10 @@ class WistiaVideoElement extends SuperVideoElement {
 
     const options = {
       autoPlay: this.autoplay,
+      silentAutoPlay: this.autoplay ? 'allow' : undefined,
       preload: this.preload ?? 'metadata',
       playsinline: this.playsInline,
-      endVideoBehavior: this.loop && 'loop',
+      endVideoBehavior: this.loop ? 'loop' : undefined,
       chromeless: !this.controls,
       playButton: this.controls,
       muted: this.defaultMuted,


### PR DESCRIPTION
Adds a config property to <wistia-video> to pass **Wistia** embed options via `_wq.push({ options })`, consistent with other elements like  Vimeo, HLS, etc.
Merges config into **Wistia** `options` with user config taking precedence over attribute-derived defaults.
Added params based on **Wistia** embed options docs.
Updates the example to demonstrate passing config to **Wistia** works.
Adds a test to ensure config is forwarded into **Wistia** options.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how `wistia-video` builds and forwards Wistia `options`, which can alter playback/controls behavior for existing embeds; test coverage added reduces regression risk.
> 
> **Overview**
> Adds a `config` property to `wistia-video-element` and merges it into the Wistia embed `options` passed via `_wq.push`, with user-provided values overriding element-derived defaults (including tweaks like `silentAutoPlay` and explicit `endVideoBehavior`).
> 
> Updates TypeScript typings to include a `WistiaEmbedOptions` shape, adds a new test asserting `config` is forwarded/precedence works, and updates the Next.js example to demonstrate passing `config` (e.g., `playerColor`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33b976888894dff4ae325eba1573a236bf11202f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->