### PR TITLE
fix: `<vimeo-video>` element race condition

### DIFF
--- a/packages/vimeo-video-element/vimeo-video-element.js
+++ b/packages/vimeo-video-element/vimeo-video-element.js
@@ -109,6 +109,10 @@ class VimeoVideoElement extends MediaPlayedRangesMixin(globalThis.HTMLElement ??
   #videoWidth = NaN;
   #videoHeight = NaN;
   #config = null;
+  /**  Distinguishes a remount from SSR hydration.
+   * See load()
+   */
+  #wasDisconnected = false;
 
   constructor() {
     super();
@@ -137,17 +141,18 @@ class VimeoVideoElement extends MediaPlayedRangesMixin(globalThis.HTMLElement ??
 
   set config(value) {
     this.#config = value;
+    this.load();
   }
 
   async load() {
     if (this.#loadRequested) return;
+
+    if (this.#hasLoaded) this.loadComplete = new PublicPromise();
+    this.#hasLoaded = true;
+
     // Wait 1 tick to allow other attributes to be set.
     await (this.#loadRequested = Promise.resolve());
     this.#loadRequested = null;
-    
-    const isFirstLoad = !this.#hasLoaded;
-    if (this.#hasLoaded) this.loadComplete = new PublicPromise();
-    this.#hasLoaded = true;
 
     this.#currentTime = 0;
     this.#duration = NaN;
@@ -197,18 +202,39 @@ class VimeoVideoElement extends MediaPlayedRangesMixin(globalThis.HTMLElement ??
     } else {
       this.#isInit = true;
 
-      let iframe = this.shadowRoot?.querySelector('iframe');
-
-      if (isFirstLoad && iframe) {
-        this.#config = JSON.parse(iframe.getAttribute('data-config') || '{}');
-      }
-
       if (!this.shadowRoot) {
         this.attachShadow({ mode: 'open' });
         this.shadowRoot.innerHTML = getTemplateHTML(namedNodeMapToObject(this.attributes), this);
-        iframe = this.shadowRoot.querySelector('iframe');
+        if (!this.#config) {
+          // SSR: read config serialised into data-config before client-side hydration
+          const ssrIframe = this.shadowRoot.querySelector('iframe');
+          this.#config = JSON.parse(ssrIframe.getAttribute('data-config') || '{}');
+        } 
+      } else {
+        /*
+        * - On remount we must rebuild the template so the iframe URL 
+        *   reflects the current src and config, the Vimeo SDK wraps the
+        *   existing iframe as-is and won't update its URL. 
+        * - On SSR hydration the iframe URL is already correct, so 
+        *   rebuilding would destroy the in-flight request and
+        *   cause a visible stutter.
+        */
+        if (this.#wasDisconnected) {
+          // Remount after disconnect:
+          //   - rebuild so src and config are reflected in the new iframe.
+          this.shadowRoot.innerHTML = getTemplateHTML(namedNodeMapToObject(this.attributes), this);
+        } else {
+          // SSR declarative shadow DOM:
+          //   - preserve iframe to avoid a redundant reload. Read config if not yet set.
+          if (!this.#config) {
+            const ssrIframe = this.shadowRoot.querySelector('iframe');
+            this.#config = JSON.parse(ssrIframe.getAttribute('data-config') || '{}');
+          }
+        }
       }
+      this.#wasDisconnected = false;
 
+      const iframe = this.shadowRoot.querySelector('iframe');
       this.api = new VimeoPlayerAPI(iframe, options);
       this.#setupApiListeners();
       await this.loadComplete;
@@ -216,6 +242,7 @@ class VimeoVideoElement extends MediaPlayedRangesMixin(globalThis.HTMLElement ??
   }
 
   disconnectedCallback() {
+    this.#wasDisconnected = true;
     this.#loadRequested = null;
     this.#hasLoaded = null;
     this.#isInit = null;

--- a/packages/vimeo-video-element/vimeo-video-element.js
+++ b/packages/vimeo-video-element/vimeo-video-element.js
@@ -138,16 +138,15 @@ class VimeoVideoElement extends MediaPlayedRangesMixin(globalThis.HTMLElement ??
   }
 
   async load() {
-    if (this.#loadRequested) return;
-
     const isFirstLoad = !this.#hasLoaded;
-
-    if (this.#hasLoaded) this.loadComplete = new PublicPromise();
-    this.#hasLoaded = true;
+    if (this.#loadRequested) return;
 
     // Wait 1 tick to allow other attributes to be set.
     await (this.#loadRequested = Promise.resolve());
     this.#loadRequested = null;
+
+    if (this.#hasLoaded) this.loadComplete = new PublicPromise();
+    this.#hasLoaded = true; // TODO: Identify how hasLoaded differs from isInit
 
     this.#currentTime = 0;
     this.#duration = NaN;

--- a/packages/vimeo-video-element/vimeo-video-element.js
+++ b/packages/vimeo-video-element/vimeo-video-element.js
@@ -237,6 +237,13 @@ class VimeoVideoElement extends MediaPlayedRangesMixin(globalThis.HTMLElement ??
     await this.loadComplete;
   }
 
+  connectedCallback() {
+    if (this.#wasDisconnected) {
+      this.load();
+    }
+    super.connectedCallback?.();
+  }
+
   disconnectedCallback() {
     this.#wasDisconnected = true;
     this.#loadRequested = null;

--- a/packages/vimeo-video-element/vimeo-video-element.js
+++ b/packages/vimeo-video-element/vimeo-video-element.js
@@ -138,15 +138,14 @@ class VimeoVideoElement extends MediaPlayedRangesMixin(globalThis.HTMLElement ??
   }
 
   async load() {
-    const isFirstLoad = !this.#hasLoaded;
     if (this.#loadRequested) return;
-
     // Wait 1 tick to allow other attributes to be set.
     await (this.#loadRequested = Promise.resolve());
     this.#loadRequested = null;
-
+    
+    const isFirstLoad = !this.#hasLoaded;
     if (this.#hasLoaded) this.loadComplete = new PublicPromise();
-    this.#hasLoaded = true; // TODO: Identify how hasLoaded differs from isInit
+    this.#hasLoaded = true;
 
     this.#currentTime = 0;
     this.#duration = NaN;
@@ -218,6 +217,7 @@ class VimeoVideoElement extends MediaPlayedRangesMixin(globalThis.HTMLElement ??
     this.#loadRequested = null;
     this.#hasLoaded = null;
     this.#isInit = null;
+    this.loadComplete = new PublicPromise();
     super.disconnectedCallback?.()
   }
 

--- a/packages/vimeo-video-element/vimeo-video-element.js
+++ b/packages/vimeo-video-element/vimeo-video-element.js
@@ -199,46 +199,39 @@ class VimeoVideoElement extends MediaPlayedRangesMixin(globalThis.HTMLElement ??
       await this.#onLoaded();
       await this.loadComplete;
       return;
-    } else {
-      this.#isInit = true;
-
-      if (!this.shadowRoot) {
-        this.attachShadow({ mode: 'open' });
-        this.shadowRoot.innerHTML = getTemplateHTML(namedNodeMapToObject(this.attributes), this);
-        if (!this.#config) {
-          // SSR: read config serialised into data-config before client-side hydration
-          const ssrIframe = this.shadowRoot.querySelector('iframe');
-          this.#config = JSON.parse(ssrIframe.getAttribute('data-config') || '{}');
-        } 
-      } else {
-        /*
-        * - On remount we must rebuild the template so the iframe URL 
-        *   reflects the current src and config, the Vimeo SDK wraps the
-        *   existing iframe as-is and won't update its URL. 
-        * - On SSR hydration the iframe URL is already correct, so 
-        *   rebuilding would destroy the in-flight request and
-        *   cause a visible stutter.
-        */
-        if (this.#wasDisconnected) {
-          // Remount after disconnect:
-          //   - rebuild so src and config are reflected in the new iframe.
-          this.shadowRoot.innerHTML = getTemplateHTML(namedNodeMapToObject(this.attributes), this);
-        } else {
-          // SSR declarative shadow DOM:
-          //   - preserve iframe to avoid a redundant reload. Read config if not yet set.
-          if (!this.#config) {
-            const ssrIframe = this.shadowRoot.querySelector('iframe');
-            this.#config = JSON.parse(ssrIframe.getAttribute('data-config') || '{}');
-          }
-        }
-      }
-      this.#wasDisconnected = false;
-
-      const iframe = this.shadowRoot.querySelector('iframe');
-      this.api = new VimeoPlayerAPI(iframe, options);
-      this.#setupApiListeners();
-      await this.loadComplete;
     }
+
+    this.#isInit = true;
+
+    /*
+     * Decide whether to build the iframe or adopt an existing one:
+     * - First client mount or remount after disconnect: build, so the iframe
+     *   URL reflects current src and config. The Vimeo SDK wraps an existing
+     *   iframe as-is and won't update its URL.
+     * - SSR declarative shadow DOM hydration: adopt the existing iframe. Its
+     *   URL is already correct, and rebuilding would destroy the in-flight
+     *   request and cause a visible stutter. Recover config from the
+     *   data-config attribute so element state matches the DOM.
+     */
+    if (!this.shadowRoot) this.attachShadow({ mode: 'open' });
+
+    const existingIframe = this.shadowRoot.querySelector('iframe');
+    const isSsrHydration = existingIframe && !this.#wasDisconnected;
+
+    if (isSsrHydration) {
+      if (!this.#config) {
+        this.#config = JSON.parse(existingIframe.getAttribute('data-config') || '{}');
+      }
+    } else {
+      this.shadowRoot.innerHTML = getTemplateHTML(namedNodeMapToObject(this.attributes), this);
+    }
+    this.#wasDisconnected = false;
+
+    oldApi?.destroy?.();
+    const iframe = this.shadowRoot.querySelector('iframe');
+    this.api = new VimeoPlayerAPI(iframe);
+    this.#setupApiListeners();
+    await this.loadComplete;
   }
 
   disconnectedCallback() {
@@ -247,7 +240,9 @@ class VimeoVideoElement extends MediaPlayedRangesMixin(globalThis.HTMLElement ??
     this.#hasLoaded = null;
     this.#isInit = null;
     this.loadComplete = new PublicPromise();
-    super.disconnectedCallback?.()
+    this.api?.destroy?.();
+    this.api = null;
+    super.disconnectedCallback?.();
   }
 
   #onLoaded = async () => {

--- a/packages/vimeo-video-element/vimeo-video-element.js
+++ b/packages/vimeo-video-element/vimeo-video-element.js
@@ -140,16 +140,13 @@ class VimeoVideoElement extends MediaPlayedRangesMixin(globalThis.HTMLElement ??
   }
 
   set config(value) {
+    if (JSON.stringify(this.#config) === JSON.stringify(value)) return;
     this.#config = value;
     this.load();
   }
 
   async load() {
     if (this.#loadRequested) return;
-
-    if (this.#hasLoaded) this.loadComplete = new PublicPromise();
-    this.#hasLoaded = true;
-
     // Wait 1 tick to allow other attributes to be set.
     await (this.#loadRequested = Promise.resolve());
     this.#loadRequested = null;
@@ -172,8 +169,14 @@ class VimeoVideoElement extends MediaPlayedRangesMixin(globalThis.HTMLElement ??
     this.api = null;
 
     if (!this.src) {
+      // Nothing to load. Leave loadComplete and #hasLoaded untouched so
+      // callers awaiting the existing loadComplete aren't orphaned if a
+      // later load() (e.g. triggered by a subsequent src) replaces it.
       return;
     }
+
+    if (this.#hasLoaded) this.loadComplete = new PublicPromise();
+    this.#hasLoaded = true;
 
     this.dispatchEvent(new Event('loadstart'));
 

--- a/packages/vimeo-video-element/vimeo-video-element.js
+++ b/packages/vimeo-video-element/vimeo-video-element.js
@@ -185,50 +185,54 @@ class VimeoVideoElement extends MediaPlayedRangesMixin(globalThis.HTMLElement ??
       ...this.#config,
     };
 
-    const onLoaded = async () => {
-      this.#readyState = 1; // HTMLMediaElement.HAVE_METADATA
-      this.dispatchEvent(new Event('loadedmetadata'));
-
-      if (this.api) {
-        this.#muted = await this.api.getMuted();
-        this.#volume = await this.api.getVolume();
-        this.dispatchEvent(new Event('volumechange'));
-
-        this.#duration = await this.api.getDuration();
-        this.dispatchEvent(new Event('durationchange'));
-      }
-
-      this.dispatchEvent(new Event('loadcomplete'));
-      this.loadComplete.resolve();
-    };
-
     if (this.#isInit) {
       this.api = oldApi;
       await this.api.loadVideo({
         ...options,
         url: this.src,
       });
-      await onLoaded();
+      await this.#onLoaded();
       await this.loadComplete;
       return;
+    } else {
+      this.#isInit = true;
+
+      let iframe = this.shadowRoot?.querySelector('iframe');
+
+      if (isFirstLoad && iframe) {
+        this.#config = JSON.parse(iframe.getAttribute('data-config') || '{}');
+      }
+
+      if (!this.shadowRoot) {
+        this.attachShadow({ mode: 'open' });
+        this.shadowRoot.innerHTML = getTemplateHTML(namedNodeMapToObject(this.attributes), this);
+        iframe = this.shadowRoot.querySelector('iframe');
+      }
+
+      this.api = new VimeoPlayerAPI(iframe, options);
+      this.#setupApiListeners();
+      await this.loadComplete;
+    }
+  }
+
+  #onLoaded = async () => {
+    this.#readyState = 1; // HTMLMediaElement.HAVE_METADATA
+    this.dispatchEvent(new Event('loadedmetadata'));
+
+    if (this.api) {
+      this.#muted = await this.api.getMuted();
+      this.#volume = await this.api.getVolume();
+      this.dispatchEvent(new Event('volumechange'));
+
+      this.#duration = await this.api.getDuration();
+      this.dispatchEvent(new Event('durationchange'));
     }
 
-    this.#isInit = true;
+    this.dispatchEvent(new Event('loadcomplete'));
+    this.loadComplete.resolve();
+  };
 
-    let iframe = this.shadowRoot?.querySelector('iframe');
-
-    if (isFirstLoad && iframe) {
-      this.#config = JSON.parse(iframe.getAttribute('data-config') || '{}');
-    }
-
-    if (!this.shadowRoot) {
-      this.attachShadow({ mode: 'open' });
-      this.shadowRoot.innerHTML = getTemplateHTML(namedNodeMapToObject(this.attributes), this);
-      iframe = this.shadowRoot.querySelector('iframe');
-    }
-
-    this.api = new VimeoPlayerAPI(iframe);
-
+  #setupApiListeners() {
     const textTracksVideo = document.createElement('video');
     this.textTracks = textTracksVideo.textTracks;
     this.api.getTextTracks().then((vimeoTracks) => {
@@ -247,7 +251,7 @@ class VimeoVideoElement extends MediaPlayedRangesMixin(globalThis.HTMLElement ??
 
     const onceLoaded = () => {
       this.api.off('loaded', onceLoaded);
-      onLoaded();
+      this.#onLoaded();
     };
     this.api.on('loaded', onceLoaded);
 
@@ -331,8 +335,6 @@ class VimeoVideoElement extends MediaPlayedRangesMixin(globalThis.HTMLElement ??
       this.#videoHeight = videoHeight;
       this.dispatchEvent(new Event('resize'));
     });
-
-    await this.loadComplete;
   }
 
   async attributeChangedCallback(attrName, oldValue, newValue) {

--- a/packages/vimeo-video-element/vimeo-video-element.js
+++ b/packages/vimeo-video-element/vimeo-video-element.js
@@ -214,6 +214,13 @@ class VimeoVideoElement extends MediaPlayedRangesMixin(globalThis.HTMLElement ??
     }
   }
 
+  disconnectedCallback() {
+    this.#loadRequested = null;
+    this.#hasLoaded = null;
+    this.#isInit = null;
+    super.disconnectedCallback?.()
+  }
+
   #onLoaded = async () => {
     this.#readyState = 1; // HTMLMediaElement.HAVE_METADATA
     this.dispatchEvent(new Event('loadedmetadata'));


### PR DESCRIPTION
Closes https://github.com/muxinc/media-elements/issues/219

## Problem

Sometimes when loading Vimeo Player (e.g. on our example switching TikTok → Vimeo) the Vimeo iframe
loaded with default styling instead of the configured color, because the `config` value was not reaching the iframe URL.

Reproduction: switch to TikTok then back to Vimeo on the Next.js example. The bug manifests as the default Vimeo blue instead of the configured pink. As this is a race condition you may need to switch multiple times for it to manifest.

How our example should look:
<img width="1890" height="656" alt="Screenshot 2026-03-20 at 5 29 43 PM" src="https://github.com/user-attachments/assets/b3b42413-9ff8-450a-b2f0-0e3d42bd7026" />
How it looks when the bug happens:
<img width="1888" height="802" alt="Screenshot 2026-03-20 at 5 30 19 PM" src="https://github.com/user-attachments/assets/6cb18c71-ae99-4175-adaf-7a9a698699d9" />


## Root cause

By checking logs I saw that when the bug happened, we were getting into the `isInit === false` case (and `load()` was running just one time), so the options weren't being applied.

Digging further, two distinct issues were combined under the "race condition":

1. **`config` setter never triggered a reload.** Setting `config` after the  element had already loaded simply mutated the private field — there was  nothing to push the new value into the iframe.
2. **Stale shadow DOM on re-attach.** When the element was disconnected and re-attached, the shadow DOM survived. On the next `load()` we hit the `isFirstLoad && iframe` branch, read the previous mount's `data-config` back into `#config`, and then reused the old iframe — so any new config set before re-attach was silently overwritten.

## What was done to address it

- **`config` setter now calls `this.load()`** (debounced via the existing tick in `load()` so it batches with concurrent `src` / attribute changes). A structural-equality short-circuit avoids redundant reloads when React re-renders
  with an equivalent config object.
- **Three-way init branching in `load()`** that distinguishes the cases of: no shadow DOM yet (first mount → build), shadow DOM survived a disconnect (remount → rebuild template so the iframe URL reflects current src/config),
  and shadow DOM came from SSR declarative shadow DOM (hydration → adopt the existing iframe; its URL is already correct and rebuilding would destroy the in-flight request, causing a visible stutter).
- **`#wasDisconnected` flag** set in `disconnectedCallback` and cleared inside `load()` — this is what lets the SSR-hydration and remount paths be told apart.
- **`connectedCallback`** re-triggers `load()` when re-attaching, since attributes don't change on re-attach and otherwise wouldn't fire `attributeChangedCallback`.
- **`disconnectedCallback`** clears `#loadRequested`, `#hasLoaded`, `#isInit`, resets `loadComplete`, and destroys the old Vimeo API instance.
  
## Extra changes (review feedback / edge cases)

- Restored `loadComplete = new PublicPromise()` to the original timing —  earlier it had been moved before the tick, which (as flagged in review) could let handlers awaiting `loadComplete` resolve prematurely against the previous
  load's promise. It now also runs *after* the early `return` for missing `src`, so a `config`-set-before-`src` no longer orphans an unresolved promise.
- Old Vimeo API instances are `destroy()`'d on reload and on disconnect to prevent leaks of stale player instances and listeners.
- Code clarity:
  - Moved API listener setup into a new `#setupApiListeners` method.
  - Moved the `#onLoaded` handler to a class method, since it's used from two places.
  - Restructured the if/else at the bottom of `load` for readability.
 
 
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `<vimeo-video>` element’s load/lifecycle behavior (including iframe reuse vs rebuild and API teardown), which could affect playback initialization timing and SSR hydration behavior if edge cases weren’t covered.
> 
> **Overview**
> Fixes a race where `config`/embed options could be missed by reworking `load()` to debounce consistently, avoid orphaning existing `loadComplete` when `src` is empty, and reload when `config` actually changes.
> 
> Adds explicit mount/unmount handling: on disconnect it resets internal load/init state and destroys the Vimeo API instance, and on reconnect it triggers a reload when the element was remounted.
> 
> Improves SSR declarative shadow DOM hydration by adopting an existing iframe (and recovering `config` from `data-config`) instead of always rebuilding the iframe, while still rebuilding on true remounts so the iframe URL reflects current `src`/`config`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 323907fc327491d18883d6c19c46d4fe44fdf2b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->