### PR TITLE
feat: Add configurable "parent" prop to twitch-video

### DIFF
--- a/packages/twitch-video-element/twitch-video-element.d.ts
+++ b/packages/twitch-video-element/twitch-video-element.d.ts
@@ -11,4 +11,6 @@ export default class CustomVideoElement extends HTMLVideoElement {
     // Time in the video where playback starts. Specifies hours, minutes, and seconds. Default: 0h0m0s (the start of the video).
     time?: number;
   }
+  // Parent domain(s) where the embed is hosted. Required by Twitch when embedding on domains other than the one that instantiates the embed.
+  parent: string | string[] | null;
 }

--- a/packages/twitch-video-element/twitch-video-element.js
+++ b/packages/twitch-video-element/twitch-video-element.js
@@ -78,18 +78,17 @@ function serializeIframeUrl(attrs, props) {
     muted: attrs.muted,
     preload: attrs.preload,
     ...props.config,
+    parent: [...new Set([].concat(props.parent ?? []).concat(globalThis.location?.hostname ?? []))].filter(Boolean),
   };
-
-  const parent = [...new Set([].concat(props.parent ?? []).concat(globalThis.location?.hostname ?? []))].filter(Boolean);
 
   if (videoMatch) {
     // Handle Twitch VODs
     const videoId = videoMatch[1];
-    return `${EMBED_BASE}/?video=v${videoId}&${serialize(params, parent)}`;
+    return `${EMBED_BASE}/?video=v${videoId}&${serialize(params)}`;
   } else if (channelMatch) {
     // Handle Twitch channels/live streams
     const channel = channelMatch[1];
-    return `${EMBED_BASE}/?channel=${channel}&${serialize(params, parent)}`;
+    return `${EMBED_BASE}/?channel=${channel}&${serialize(params)}`;
   }
 
   return '';
@@ -133,6 +132,7 @@ class TwitchVideoElement extends (globalThis.HTMLElement ?? class {}) {
   }
 
   set parent(value) {
+    if (this.#parent === value) return;
     this.#parent = value;
     this.load();
   }
@@ -432,7 +432,7 @@ function escapeHtml(str) {
     .replace(/`/g, '&#x60;');
 }
 
-function serialize(props, parent) {
+function serialize({ parent, ...props }) {
   const params = new URLSearchParams(filterParams(props));
   [].concat(parent).filter(Boolean).forEach(d => params.append('parent', d));
   return String(params);

--- a/packages/twitch-video-element/twitch-video-element.js
+++ b/packages/twitch-video-element/twitch-video-element.js
@@ -72,7 +72,6 @@ function serializeIframeUrl(attrs, props) {
   const channelMatch = attrs.src.match(MATCH_CHANNEL);
 
   const params = {
-    parent: globalThis.location?.hostname,
     // ?controls=true is enabled by default in the iframe
     controls: attrs.controls === '' ? null : false,
     autoplay: attrs.autoplay === '' ? null : false,
@@ -81,14 +80,16 @@ function serializeIframeUrl(attrs, props) {
     ...props.config,
   };
 
+  const parent = [...new Set([].concat(props.parent ?? []).concat(globalThis.location?.hostname ?? []))].filter(Boolean);
+
   if (videoMatch) {
     // Handle Twitch VODs
     const videoId = videoMatch[1];
-    return `${EMBED_BASE}/?video=v${videoId}&${serialize(params)}`;
+    return `${EMBED_BASE}/?video=v${videoId}&${serialize(params, parent)}`;
   } else if (channelMatch) {
     // Handle Twitch channels/live streams
     const channel = channelMatch[1];
-    return `${EMBED_BASE}/?channel=${channel}&${serialize(params)}`;
+    return `${EMBED_BASE}/?channel=${channel}&${serialize(params, parent)}`;
   }
 
   return '';
@@ -111,10 +112,12 @@ class TwitchVideoElement extends (globalThis.HTMLElement ?? class {}) {
   #seeking = false;
   #readyState = 0;
   #config = null;
+  #parent = null;
 
   constructor() {
     super();
     this.#upgradeProperty('config');
+    this.#upgradeProperty('parent');
   }
 
   get config() {
@@ -123,6 +126,15 @@ class TwitchVideoElement extends (globalThis.HTMLElement ?? class {}) {
 
   set config(value) {
     this.#config = value;
+  }
+
+  get parent() {
+    return this.#parent ?? this.getAttribute('parent');
+  }
+
+  set parent(value) {
+    this.#parent = value;
+    this.load();
   }
 
   async load() {
@@ -420,8 +432,10 @@ function escapeHtml(str) {
     .replace(/`/g, '&#x60;');
 }
 
-function serialize(props) {
-  return String(new URLSearchParams(filterParams(props)));
+function serialize(props, parent) {
+  const params = new URLSearchParams(filterParams(props));
+  [].concat(parent).filter(Boolean).forEach(d => params.append('parent', d));
+  return String(params);
 }
 
 function filterParams(props) {


### PR DESCRIPTION
Fixes [#225](https://github.com/muxinc/media-elements/issues/225)

Adds a `parent` prop/attribute to `<twitch-video-element>` that accepts a string or array of domain strings, allowing embeds hosted across multiple domains to pass all required parent values to the Twitch iframe URL.

`globalThis.location?.hostname` is still included automatically, so existing usage is unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the Twitch iframe URL is constructed and when the element reloads, which could affect embed initialization if `parent` values are incorrect or duplicated. No auth/data-handling logic is involved.
> 
> **Overview**
> Adds a configurable `parent` property/attribute to `twitch-video-element`, allowing callers to provide one or more Twitch-required parent domains.
> 
> Updates iframe URL serialization to *always* include the current `location.hostname` plus any user-provided parents (deduped) and emits multiple `parent=` query params as Twitch expects; changing `parent` now triggers a reload of the embed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b7d606017dff5853d8c60b44739075b3a63bfa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->