### PR TITLE
Fix Chromecast for HLS streams with separate audio renditions

### DIFF
--- a/packages/castable-video/castable-mixin.js
+++ b/packages/castable-video/castable-mixin.js
@@ -140,7 +140,11 @@ export const CastableMediaMixin = (superclass) =>
       mediaInfo.metadata.title = this.title;
       mediaInfo.metadata.images = [{ url: this.poster }];
 
-      if (isHls(this.castSrc)) {
+      const hlsDetected = await isHls(this.castSrc);
+      if (hlsDetected) {
+        if (!mediaInfo.contentType) {
+          mediaInfo.contentType = 'application/x-mpegURL';
+        }
         const segmentFormat = await getPlaylistSegmentFormat(this.castSrc);
         const isFragmentedMP4 = segmentFormat?.includes('m4s') || segmentFormat?.includes('mp4');
         if (isFragmentedMP4) {
@@ -211,10 +215,13 @@ export const CastableMediaMixin = (superclass) =>
     // Allow the cast source url to be different than <video src>, could be a blob.
     get castSrc() {
       // Try the first <source src> for usage with even more native markup.
+      const currentSrc = this.currentSrc;
+      const resolvedSrc = currentSrc?.startsWith('blob:') ? undefined : currentSrc;
       return (
         this.getAttribute('cast-src') ??
         this.querySelector('source')?.src ??
-        this.currentSrc
+        resolvedSrc ??
+        this.getAttribute('src') ?? undefined
       );
     }
 

--- a/packages/castable-video/castable-utils.js
+++ b/packages/castable-video/castable-utils.js
@@ -146,6 +146,10 @@ function parseSegment(playlistContent){
 }
 
 export async function isHls(url) {
+  if (!url) return false;
+  if (/\.m3u8?(\?.*)?$/i.test(url)) return true;
+  if (url.startsWith('blob:')) return false;
+
   try {
     const response = await fetch(url, {method: 'HEAD'});
     const contentType = response.headers.get('Content-Type');
@@ -158,6 +162,7 @@ export async function isHls(url) {
 }
 
 export async function getPlaylistSegmentFormat(url) {
+  if (!url || url.startsWith('blob:')) return undefined;
   try {
     const mainManifestContent = await (await fetch(url)).text();
     let availableChunksContent = mainManifestContent;


### PR DESCRIPTION
Chromecast casting failed for HLS streams with separate audio renditions (TS video + raw AAC audio). 

Root causes:
1. `isHls()` was called without `await` it always returned truthy (a Promise), masking the real HLS check
2. When hls.js handles playback, `video.currentSrc` becomes a `blob:` MediaSource URL that can't be fetched or sent to a Cast receiver, so `castSrc` was resolving to an unusable URL
3. `contentType` was never set for HLS streams, so the Cast receiver didn't know how to handle them

## Changes

- Skip `blob:` URLs in `castSrc`, fall back to the `src` attribute
- Properly `await isHls()` and auto-set `contentType: application/x-mpegURL` for HLS streams
- Guard `isHls()` and `getPlaylistSegmentFormat()` against `blob:` URLs to prevent bad fetches

Fixes [224](https://github.com/muxinc/media-elements/issues/224) 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Chromecast load logic and HLS detection, which can affect remote playback for a wide range of streams. Changes are localized but involve network probing (`fetch`) and source resolution edge-cases (e.g., `blob:` URLs).
> 
> **Overview**
> Fixes Chromecast failures for HLS by properly awaiting `isHls()` and auto-setting `MediaInfo.contentType` to `application/x-mpegURL` when an HLS manifest is detected.
> 
> Improves cast source resolution by ignoring `blob:` `currentSrc` values (common with MSE/hls.js) and falling back to the element `src`/`cast-src`, and hardens `isHls()`/`getPlaylistSegmentFormat()` to early-return for missing or `blob:` URLs to avoid invalid `fetch`es.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ef743b1bd1b6b648a6f417c3c17e7df1af91bab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->