### PR TITLE
Revert castable video fix for convention commit

### DIFF
--- a/packages/castable-video/castable-mixin.js
+++ b/packages/castable-video/castable-mixin.js
@@ -157,18 +157,14 @@ export const CastableMediaMixin = (superclass) =>
         if (!mediaInfo.contentType) {
           mediaInfo.contentType = 'application/x-mpegURL';
         }
-        const { videoFormat, audioFormat } = await getPlaylistSegmentFormat(this.castSrc);
-
-        const isVideoFMP4 = videoFormat?.includes('m4s') || videoFormat?.includes('mp4') || videoFormat?.includes('m4a');
-        if (isVideoFMP4) {
+        const segmentFormat = await getPlaylistSegmentFormat(this.castSrc);
+        const isFragmentedMP4 = segmentFormat?.includes('m4s') || segmentFormat?.includes('mp4');
+        if (isFragmentedMP4) {
           mediaInfo.hlsSegmentFormat = chrome.cast.media.HlsSegmentFormat.FMP4;
           mediaInfo.hlsVideoSegmentFormat = chrome.cast.media.HlsVideoSegmentFormat.FMP4;
-        } else if (audioFormat?.includes('aac')) {
-          mediaInfo.hlsSegmentFormat = chrome.cast.media.HlsSegmentFormat.AAC;
-          mediaInfo.hlsVideoSegmentFormat = chrome.cast.media.HlsVideoSegmentFormat.MPEG2_TS;
-        } else if (videoFormat?.includes('ts') || audioFormat?.includes('ts')) {
+        } else if (segmentFormat?.includes('ts')) {
           mediaInfo.hlsSegmentFormat = chrome.cast.media.HlsSegmentFormat.TS;
-          mediaInfo.hlsVideoSegmentFormat = chrome.cast.media.HlsVideoSegmentFormat.MPEG2_TS;
+          mediaInfo.hlsVideoSegmentFormat = chrome.cast.media.HlsVideoSegmentFormat.TS;
         }
       }
 

--- a/packages/castable-video/castable-utils.js
+++ b/packages/castable-video/castable-utils.js
@@ -118,17 +118,6 @@ function getFormat(segment) {
   return match ? match[1] : null;
 }
 
-function parseAudioRenditionUrl(playlistContent) {
-  for (const line of playlistContent.split('\n')) {
-    const trimmed = line.trim();
-    if (trimmed.startsWith('#EXT-X-MEDIA') && /TYPE=AUDIO/i.test(trimmed)) {
-      const match = trimmed.match(/URI="([^"]+)"/i);
-      if (match) return match[1];
-    }
-  }
-  return undefined;
-}
-
 function parsePlaylistUrls(playlistContent) {
   const lines = playlistContent.split('\n');
   const urls = [];
@@ -153,7 +142,7 @@ function parseSegment(playlistContent){
 
   const url = lines.find(line => !line.trim().startsWith('#') && line.trim() !== '');
 
-  return url?.trim();
+  return url;
 }
 
 export async function isHls(url) {
@@ -173,36 +162,22 @@ export async function isHls(url) {
 }
 
 export async function getPlaylistSegmentFormat(url) {
-  if (!url || url.startsWith('blob:')) return { videoFormat: undefined, audioFormat: undefined };
+  if (!url || url.startsWith('blob:')) return undefined;
   try {
     const mainManifestContent = await (await fetch(url)).text();
-    let videoChunksContent = mainManifestContent;
+    let availableChunksContent = mainManifestContent;
 
     const playlists = parsePlaylistUrls(mainManifestContent);
-    if (playlists.length > 0) {
+    if (playlists.length > 0) {    
       const chosenPlaylistUrl = new URL(playlists[0], url).toString();
-      videoChunksContent = await (await fetch(chosenPlaylistUrl)).text();
+      availableChunksContent = await (await fetch(chosenPlaylistUrl)).text();
     }
 
-    const videoSegment = parseSegment(videoChunksContent);
-    const videoFormat = getFormat(videoSegment);
-
-    const audioRenditionPath = parseAudioRenditionUrl(mainManifestContent);
-    let audioFormat = videoFormat;
-    if (audioRenditionPath) {
-      try {
-        const audioPlaylistUrl = new URL(audioRenditionPath, url).toString();
-        const audioChunksContent = await (await fetch(audioPlaylistUrl)).text();
-        const audioSegment = parseSegment(audioChunksContent);
-        audioFormat = getFormat(audioSegment) ?? videoFormat;
-      } catch (err) {
-        console.error('Error while trying to parse the audio rendition playlist', err);
-      }
-    }
-
-    return { videoFormat, audioFormat };
+    const segment = parseSegment(availableChunksContent);
+    const format = getFormat(segment);
+    return format
   } catch (err) {
     console.error('Error while trying to parse the manifest playlist', err);
-    return { videoFormat: undefined, audioFormat: undefined };
+    return undefined;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes HLS format detection and the Cast `hls*SegmentFormat` values used at load time; mis-detection could cause some HLS streams to fail or use suboptimal playback settings.
> 
> **Overview**
> Updates Chromecast HLS loading to infer segment format from a *single* detected segment extension (via `getPlaylistSegmentFormat`) and map it to Cast’s FMP4 vs TS settings.
> 
> `getPlaylistSegmentFormat` is simplified to return just one format string (or `undefined`) and drops separate audio-rendition parsing/return values, with `castable-mixin` updated accordingly (including using `HlsVideoSegmentFormat.TS` for TS streams).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75b2bfb7cf53824502bbe56ffd7a09ca690e50ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->