### PR TITLE
fix: correct hlsSegmentFormat for HLS streams with AAC audio in castable-video

### DIFF
--- a/packages/castable-video/castable-mixin.js
+++ b/packages/castable-video/castable-mixin.js
@@ -157,14 +157,18 @@ export const CastableMediaMixin = (superclass) =>
         if (!mediaInfo.contentType) {
           mediaInfo.contentType = 'application/x-mpegURL';
         }
-        const segmentFormat = await getPlaylistSegmentFormat(this.castSrc);
-        const isFragmentedMP4 = segmentFormat?.includes('m4s') || segmentFormat?.includes('mp4');
-        if (isFragmentedMP4) {
+        const { videoFormat, audioFormat } = await getPlaylistSegmentFormat(this.castSrc);
+
+        const isVideoFMP4 = videoFormat?.includes('m4s') || videoFormat?.includes('mp4') || videoFormat?.includes('m4a');
+        if (isVideoFMP4) {
           mediaInfo.hlsSegmentFormat = chrome.cast.media.HlsSegmentFormat.FMP4;
           mediaInfo.hlsVideoSegmentFormat = chrome.cast.media.HlsVideoSegmentFormat.FMP4;
-        } else if (segmentFormat?.includes('ts')) {
+        } else if (audioFormat?.includes('aac')) {
+          mediaInfo.hlsSegmentFormat = chrome.cast.media.HlsSegmentFormat.AAC;
+          mediaInfo.hlsVideoSegmentFormat = chrome.cast.media.HlsVideoSegmentFormat.MPEG2_TS;
+        } else if (videoFormat?.includes('ts') || audioFormat?.includes('ts')) {
           mediaInfo.hlsSegmentFormat = chrome.cast.media.HlsSegmentFormat.TS;
-          mediaInfo.hlsVideoSegmentFormat = chrome.cast.media.HlsVideoSegmentFormat.TS;
+          mediaInfo.hlsVideoSegmentFormat = chrome.cast.media.HlsVideoSegmentFormat.MPEG2_TS;
         }
       }
 

--- a/packages/castable-video/castable-utils.js
+++ b/packages/castable-video/castable-utils.js
@@ -118,6 +118,17 @@ function getFormat(segment) {
   return match ? match[1] : null;
 }
 
+function parseAudioRenditionUrl(playlistContent) {
+  for (const line of playlistContent.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('#EXT-X-MEDIA') && /TYPE=AUDIO/i.test(trimmed)) {
+      const match = trimmed.match(/URI="([^"]+)"/i);
+      if (match) return match[1];
+    }
+  }
+  return undefined;
+}
+
 function parsePlaylistUrls(playlistContent) {
   const lines = playlistContent.split('\n');
   const urls = [];
@@ -142,7 +153,7 @@ function parseSegment(playlistContent){
 
   const url = lines.find(line => !line.trim().startsWith('#') && line.trim() !== '');
 
-  return url;
+  return url?.trim();
 }
 
 export async function isHls(url) {
@@ -162,22 +173,36 @@ export async function isHls(url) {
 }
 
 export async function getPlaylistSegmentFormat(url) {
-  if (!url || url.startsWith('blob:')) return undefined;
+  if (!url || url.startsWith('blob:')) return { videoFormat: undefined, audioFormat: undefined };
   try {
     const mainManifestContent = await (await fetch(url)).text();
-    let availableChunksContent = mainManifestContent;
+    let videoChunksContent = mainManifestContent;
 
     const playlists = parsePlaylistUrls(mainManifestContent);
-    if (playlists.length > 0) {    
+    if (playlists.length > 0) {
       const chosenPlaylistUrl = new URL(playlists[0], url).toString();
-      availableChunksContent = await (await fetch(chosenPlaylistUrl)).text();
+      videoChunksContent = await (await fetch(chosenPlaylistUrl)).text();
     }
 
-    const segment = parseSegment(availableChunksContent);
-    const format = getFormat(segment);
-    return format
+    const videoSegment = parseSegment(videoChunksContent);
+    const videoFormat = getFormat(videoSegment);
+
+    const audioRenditionPath = parseAudioRenditionUrl(mainManifestContent);
+    let audioFormat = videoFormat;
+    if (audioRenditionPath) {
+      try {
+        const audioPlaylistUrl = new URL(audioRenditionPath, url).toString();
+        const audioChunksContent = await (await fetch(audioPlaylistUrl)).text();
+        const audioSegment = parseSegment(audioChunksContent);
+        audioFormat = getFormat(audioSegment) ?? videoFormat;
+      } catch (err) {
+        console.error('Error while trying to parse the audio rendition playlist', err);
+      }
+    }
+
+    return { videoFormat, audioFormat };
   } catch (err) {
     console.error('Error while trying to parse the manifest playlist', err);
-    return undefined;
+    return { videoFormat: undefined, audioFormat: undefined };
   }
 }


### PR DESCRIPTION
## Problem

Chromecast playback stalls silently for HLS streams that have separate audio
renditions using raw ADTS AAC segments (`.aac`). The LOAD request sent to the
receiver had `hlsSegmentFormat: "ts"` because format detection only inspected
the video variant playlist then applied that format to the audio field too.

The receiver interprets `hlsSegmentFormat` as the audio segment format. Telling
it "audio is MPEG-TS" when it receives raw `.aac` files causes it to hang
indefinitely with no error.

Fixes [224](https://github.com/muxinc/media-elements/issues/224).

## Changes

**`castable-utils.js`**
- Add `parseAudioRenditionUrl()` — finds the first `#EXT-X-MEDIA TYPE=AUDIO`
  URI in the master playlist
- `getPlaylistSegmentFormat()` now separately detects video and audio formats,
  fetching the audio rendition playlist when present
- Returns `{ videoFormat, audioFormat }` instead of a single string
- Fix `parseSegment()` to trim the returned line (handles CRLF line endings)

**`castable-mixin.js`**
- Set `hlsSegmentFormat` from `audioFormat`, `hlsVideoSegmentFormat` from
  `videoFormat`
- `.aac` audio → `hlsSegmentFormat = AAC`, `hlsVideoSegmentFormat = MPEG2_TS`
- TS video/audio → `hlsSegmentFormat = TS`, `hlsVideoSegmentFormat = MPEG2_TS`
  (also fixes the latent bug where `HlsVideoSegmentFormat.TS` was `undefined`)
- FMP4 → both remain `FMP4`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect HLS manifest parsing and the Chromecast LOAD request fields; incorrect detection could break casting for some HLS variants, but the scope is limited to HLS-specific casting behavior.
> 
> **Overview**
> Fixes Chromecast HLS playback for manifests with separate audio renditions by **detecting audio and video segment formats independently** and mapping them to the correct Cast `hlsSegmentFormat` (audio) vs `hlsVideoSegmentFormat` (video).
> 
> `getPlaylistSegmentFormat()` now returns `{ videoFormat, audioFormat }`, trims parsed segment lines, and (when present) fetches the first `#EXT-X-MEDIA TYPE=AUDIO` rendition playlist to determine audio segment type; `castable-mixin.js` uses this to set `AAC` audio correctly and to use `MPEG2_TS` for TS video instead of the previously incorrect/undefined enum usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 947ef46196cbe0ad89b71828ef01c84f16f0c6ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->