### PR TITLE
fix: guard HTMLElement reference for SSR in peertube-video-element

### DIFF
--- a/packages/peertube-video-element/peertube-video-element.js
+++ b/packages/peertube-video-element/peertube-video-element.js
@@ -143,7 +143,7 @@ class PublicPromise extends Promise {
   }
 }
 
-class PeerTubeVideoElement extends MediaPlayedRangesMixin(MediaTracksMixin(HTMLElement)) {
+class PeerTubeVideoElement extends MediaPlayedRangesMixin(MediaTracksMixin(globalThis.HTMLElement ?? class {})) {
   static getTemplateHTML = getTemplateHTML;
   static shadowRootOptions = { mode: "open" };
   static observedAttributes = [


### PR DESCRIPTION
`PeerTubeVideoElement `extended `HTMLElemen`t directly, causing `ReferenceError: HTMLElement is not defined` during Next.js SSR/build. Changed to `globalThis.HTMLElement ?? class {} `— the same pattern used by all other iframe-based elements in this repo (youtube, vimeo, etc.).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small compatibility change to avoid `ReferenceError` in SSR/build environments; behavior in browsers should remain unchanged.
> 
> **Overview**
> Prevents SSR/build-time failures by changing `PeerTubeVideoElement` to extend `globalThis.HTMLElement ?? class {}` instead of directly referencing `HTMLElement`, avoiding `ReferenceError: HTMLElement is not defined` when running outside the browser.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5328ae0388e52a50a179a92533b85eb746fa004. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->