### PR TITLE
docs: add browser support section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ The packages in this repo are distributed as **ESNext** — including modern Jav
 
 If you need to support browsers that don't have these features natively (e.g. Safari < 14.1), configure your bundler to include these packages in its transpilation step and set your desired target (e.g. `es2019`).
 
-> **Note:** [`media-chrome`](https://github.com/muxinc/media-chrome) ships pre-transpiled to `es2019`. The packages here intentionally do not — expect to handle transpilation yourself.
+> **Note:** Unlike [`media-chrome`](https://github.com/muxinc/media-chrome), which ships pre-transpiled to `es2019`, the packages in this repository are distributed as ESNext. You are responsible for configuring your build pipeline to handle any necessary transpilation for your target environments.

--- a/README.md
+++ b/README.md
@@ -22,3 +22,11 @@ A collection of HTMLMediaElement compatible elements and add-ons.
 | [`<twitch-video>`](packages/twitch-video-element)                                    | A custom video element for Twitch player.                                      |
 | [`<cloudflare-video>`](packages/cloudflare-video-element)                            | A custom video element for Cloudflare Stream.                                  |
 | [`<peertube-video>`](packages/peertube-video-element)                                | A custom video element for PeerTube player.                                    |
+
+## Browser support
+
+The packages in this repo are distributed as **ESNext** — including modern JavaScript features like [private class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties). This is intentional: these packages are designed to be imported and processed by your own bundler or build tool, which is responsible for transpiling to your target browsers.
+
+If you need to support browsers that don't have these features natively (e.g. Safari < 14.1), configure your bundler to include these packages in its transpilation step and set your desired target (e.g. `es2019`).
+
+> **Note:** [`media-chrome`](https://github.com/muxinc/media-chrome) ships pre-transpiled to `es2019`. The packages here intentionally do not — expect to handle transpilation yourself.


### PR DESCRIPTION
Adds a "Browser support" section to the root README clarifying that
packages in this repo are distributed as ESNext (including private class
fields) and that consumers are responsible for transpiling to their
target browsers.

Also notes the intentional contrast with `media-chrome`, which ships
pre-transpiled to `es2019`.

Fixes #36


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that clarifies consumer bundler/transpilation responsibilities; no runtime or build logic is modified.
> 
> **Overview**
> Adds a new **Browser support** section to `README.md` clarifying that packages are published as **ESNext** (including features like private class fields) and that consumers must transpile them for older targets (e.g. Safari < 14.1 / `es2019`).
> 
> Also adds a note contrasting this with `media-chrome`, which ships pre-transpiled to `es2019`, and fixes the missing trailing newline in the README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cb82872d5812524dad77509178dc58ef6644fbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->