### PR TITLE
fix: peertube sample urls

### DIFF
--- a/packages/peertube-video-element/index.html
+++ b/packages/peertube-video-element/index.html
@@ -41,7 +41,7 @@
     <h2>With <a href="https://github.com/muxinc/media-chrome" target="_blank">Media Chrome</a></h2>
 
     <media-controller>
-      <peertube-video id="t2" src="https://tv.dilstories.com/videos/embed/oDbRb2hnUsoioPSsxXULWA" slot="media"></peertube-video>
+      <peertube-video id="t2" src="https://video.mshparisnord.fr/w/7r2FxoQdYjun6tYWJfHUCa" slot="media"></peertube-video>
       <media-captions-menu hidden anchor="auto"></media-captions-menu>
       <media-rendition-menu anchor="auto" hidden>
         <div slot="header">Quality</div>

--- a/packages/peertube-video-element/peertube-video-element.js
+++ b/packages/peertube-video-element/peertube-video-element.js
@@ -143,7 +143,7 @@ class PublicPromise extends Promise {
   }
 }
 
-class PeerTubeVideoElement extends MediaPlayedRangesMixin(MediaTracksMixin(HTMLElement)) {
+class PeerTubeVideoElement extends MediaPlayedRangesMixin(MediaTracksMixin(globalThis.HTMLElement ?? class {})) {
   static getTemplateHTML = getTemplateHTML;
   static shadowRootOptions = { mode: "open" };
   static observedAttributes = [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: updates only a hardcoded demo `src` URL in `index.html` with no runtime logic or API changes.
> 
> **Overview**
> Updates the `packages/peertube-video-element/index.html` demo so the Media Chrome example (`#t2`) uses the same `video.mshparisnord.fr` sample URL as the basic example, replacing the previous `tv.dilstories.com` embed link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44fe8f4d9294804e8811b7d35a82c6998e3f031c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->