### PR TITLE
fix: format castable mixin

### DIFF
--- a/packages/castable-video/castable-mixin.js
+++ b/packages/castable-video/castable-mixin.js
@@ -7,7 +7,7 @@ import {
   currentSession,
   getDefaultCastOptions,
   isHls,
-  getPlaylistSegmentFormat
+  getPlaylistSegmentFormat,
 } from './castable-utils.js';
 
 /**
@@ -21,7 +21,6 @@ import {
  */
 export const CastableMediaMixin = (superclass) =>
   class CastableMedia extends superclass {
-
     static observedAttributes = [
       ...(superclass.observedAttributes ?? []),
       'cast-src',
@@ -50,7 +49,7 @@ export const CastableMediaMixin = (superclass) =>
         }
 
         privateProps.set(this, {
-          loadOnPrompt: () => this.#loadOnPrompt()
+          loadOnPrompt: () => this.#loadOnPrompt(),
         });
 
         return (this.#remote = new RemotePlayback(this));
@@ -126,10 +125,7 @@ export const CastableMediaMixin = (superclass) =>
             activeTrackIds.push(trackId);
           }
 
-          const track = new chrome.cast.media.Track(
-            trackId,
-            chrome.cast.media.TrackType.TEXT
-          );
+          const track = new chrome.cast.media.Track(trackId, chrome.cast.media.TrackType.TEXT);
           track.trackContentId = trackEl.src;
           track.trackContentType = 'text/vtt';
           track.subtype =
@@ -159,7 +155,8 @@ export const CastableMediaMixin = (superclass) =>
         }
         const { videoFormat, audioFormat } = await getPlaylistSegmentFormat(this.castSrc);
 
-        const isVideoFMP4 = videoFormat?.includes('m4s') || videoFormat?.includes('mp4') || videoFormat?.includes('m4a');
+        const isVideoFMP4 =
+          videoFormat?.includes('m4s') || videoFormat?.includes('mp4') || videoFormat?.includes('m4a');
         if (isVideoFMP4) {
           mediaInfo.hlsSegmentFormat = chrome.cast.media.HlsSegmentFormat.FMP4;
           mediaInfo.hlsVideoSegmentFormat = chrome.cast.media.HlsVideoSegmentFormat.FMP4;
@@ -237,7 +234,8 @@ export const CastableMediaMixin = (superclass) =>
         this.getAttribute('cast-src') ??
         this.querySelector('source')?.src ??
         resolvedSrc ??
-        this.getAttribute('src') ?? undefined
+        this.getAttribute('src') ??
+        undefined
       );
     }
 
@@ -303,10 +301,7 @@ export const CastableMediaMixin = (superclass) =>
 
     set muted(val) {
       if (this.#castPlayer) {
-        if (
-          (val && !this.#castPlayer.isMuted) ||
-          (!val && this.#castPlayer.isMuted)
-        ) {
+        if ((val && !this.#castPlayer.isMuted) || (!val && this.#castPlayer.isMuted)) {
           this.#castPlayer.controller?.muteOrUnmute();
         }
         return;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Pure formatting/whitespace changes in `castable-mixin.js` with no intended runtime behavior changes; low risk aside from inadvertent formatting-related syntax mistakes.
> 
> **Overview**
> Applies code-style formatting updates to `packages/castable-video/castable-mixin.js` (trailing commas, line wrapping, and minor expression reformatting) without changing casting behavior or APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fe7aea03474834b26da028aa5a975978d84fb7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->