### PR TITLE
fix: publish peertube to npm on release

### DIFF
--- a/.github/release-please/.release-please-manifest.json
+++ b/.github/release-please/.release-please-manifest.json
@@ -12,6 +12,7 @@
   "packages/spotify-audio-element": "1.0.4",
   "packages/super-media-element": "1.4.2",
   "packages/tiktok-video-element": "0.1.2",
+  "packages/peertube-video-element": "0.1.0",
   "packages/twitch-video-element": "0.2.0",
   "packages/videojs-video-element": "1.4.8",
   "packages/vimeo-video-element": "1.7.1",

--- a/.github/release-please/.release-please-manifest.json
+++ b/.github/release-please/.release-please-manifest.json
@@ -12,7 +12,7 @@
   "packages/spotify-audio-element": "1.0.4",
   "packages/super-media-element": "1.4.2",
   "packages/tiktok-video-element": "0.1.2",
-  "packages/peertube-video-element": "0.1.0",
+  "packages/peertube-video-element": "1.0.0",
   "packages/twitch-video-element": "0.2.0",
   "packages/videojs-video-element": "1.4.8",
   "packages/vimeo-video-element": "1.7.1",

--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -19,6 +19,7 @@
     "packages/spotify-audio-element": {},
     "packages/super-media-element": {},
     "packages/tiktok-video-element": {},
+    "packages/peertube-video-element": {},
     "packages/twitch-video-element": {},
     "packages/videojs-video-element": {},
     "packages/vimeo-video-element": {},


### PR DESCRIPTION
Adds missing pre release data for package publishing 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change to ensure `packages/peertube-video-element` is tracked and released/published by release-please; no runtime code paths are affected.
> 
> **Overview**
> Adds `packages/peertube-video-element` to release-please’s managed packages by updating `.github/release-please/release-please-config.json` and seeding `.github/release-please/.release-please-manifest.json` with an initial `1.0.0` version so it is included in automated releases/NPM publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b97e375caa137f0559a6472eee51f8b6156e5710. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->