### PR TITLE
fix: add workflow_dispatch trigger to CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   lint:
@@ -49,21 +50,21 @@ jobs:
       - uses: actions/checkout@v4
         # these if statements ensure that a publication only occurs when
         # a new release is created:
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ steps.release.outputs.releases_created == 'true' || github.event_name == 'workflow_dispatch' }}
 
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ steps.release.outputs.releases_created == 'true' || github.event_name == 'workflow_dispatch' }}
 
       - run: npm ci
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ steps.release.outputs.releases_created == 'true' || github.event_name == 'workflow_dispatch' }}
 
       - run: npm run build
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ steps.release.outputs.releases_created == 'true' || github.event_name == 'workflow_dispatch' }}
 
       - run: npm exec -c publish-packages
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ steps.release.outputs.releases_created == 'true' || github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
Adds workflow_dispatch to the CD workflow so the pipeline can be manually triggered from the GitHub Actions UI.

This unblocks npm publishes when the automated publish step was missed (e.g. castable-video@1.1.15 and peertube-video-element@1.1.0 are currently on GitHub releases but not on npm).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; it expands when publish steps can run (manual dispatch), so reviewers should ensure manual runs won’t accidentally publish unintended versions.
> 
> **Overview**
> Adds a `workflow_dispatch` trigger to the `CD` GitHub Actions workflow so it can be run manually from the Actions UI.
> 
> Updates the `release` job gating so the checkout/build/publish steps run either when `release-please` creates a release or when the workflow is manually dispatched, enabling manual npm publishes when automation is missed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c6879d9c3c843bfa714d4bfb4bf92cb098e237a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->