### PR TITLE
fix: use private field in #castPlayer getter to avoid side effects

### DIFF
--- a/packages/castable-video/castable-mixin.js
+++ b/packages/castable-video/castable-mixin.js
@@ -59,7 +59,7 @@ export const CastableMediaMixin = (superclass) =>
     }
 
     get #castPlayer() {
-      return privateProps.get(this.remote)?.getCastPlayer?.();
+      return privateProps.get(this.#remote)?.getCastPlayer?.();
     }
 
     disconnectedCallback() {


### PR DESCRIPTION
- The `#castPlayer` getter was calling `this.remote` (the public getter)
  instead of `this.#remote` (the private field) to look up the cast player
- `this.remote` has side effects: it loads the Cast SDK and creates a
  `RemotePlayback` instance if one doesn't exist yet
- This means every internal property access (`paused`, `muted`, `volume`,
  `currentTime`, etc.) was potentially triggering Cast SDK initialization
  unintentionally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, one-line internal change that prevents unintended Cast SDK/`RemotePlayback` initialization during internal property reads.
> 
> **Overview**
> Updates the `#castPlayer` getter in `castable-mixin.js` to reference the private `#remote` field instead of the public `remote` getter, avoiding side effects like loading the Cast framework or creating a `RemotePlayback` instance during internal state access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bb675eaa02cb2c6321f464a9fd7a3ed21c6d275. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->