### PR TITLE
fix: prevent unnecessary <vimeo-video> reload when config is undefined

### DIFF
--- a/packages/vimeo-video-element/vimeo-video-element.js
+++ b/packages/vimeo-video-element/vimeo-video-element.js
@@ -140,6 +140,10 @@ class VimeoVideoElement extends MediaPlayedRangesMixin(globalThis.HTMLElement ??
   }
 
   set config(value) {
+    // Normalize undefined to null so config = undefined (e.g. from react-player)
+    // matches the null default and doesn't trigger an unnecessary reload. Needed
+    // because JSON.stringify(undefined) is undefined (not the string "null").
+    value ??= null;
     if (JSON.stringify(this.#config) === JSON.stringify(value)) return;
     this.#config = value;
     this.load();


### PR DESCRIPTION
Closes https://github.com/muxinc/media-elements/issues/249

## Problem

In React (e.g. `react-player`), `<vimeo-video>` reloads on the first render and loses
any `currentTime` set beforehand. Regression from #220.

## Cause

The `config` setter skips reloading when the value is unchanged by comparing
`JSON.stringify(this.#config)` with `JSON.stringify(value)`. `#config` defaults to
`null`, but `JSON.stringify(undefined)` is `undefined` (not the string `"null"`), so
setting `config = undefined` (what react-player does when no config is passed) never
matches the default and triggers an unnecessary `load()`, which reloads the video and
resets `currentTime`.

## Fix

Normalize `undefined` to `null` at the start of the setter (`value ??= null`) so it
matches the default and is treated as a no-op.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line normalization in the config setter; no auth, data, or lifecycle behavior beyond avoiding spurious reloads.
> 
> **Overview**
> Adds a small guard in the **`config` setter** on `vimeo-video-element`: **`undefined` is coerced to `null`** before the equality check.
> 
> That way integrations that assign `config = undefined` (e.g. **react-player**) are treated the same as the element's default **`null`** config. Without this, `JSON.stringify(undefined)` is `undefined`, so it never matches `JSON.stringify(null)` and the setter incorrectly calls **`load()`** even though nothing meaningful changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34a5aea4d3eee4a7a377569cfba65effbcb99c50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->