### PR TITLE
fix: pin zora to 6.0.0 in test importmaps

### DIFF
--- a/packages/cloudflare-video-element/test/index.html
+++ b/packages/cloudflare-video-element/test/index.html
@@ -3,7 +3,7 @@
 <script type="importmap">
   {
     "imports": {
-      "zora": "https://cdn.jsdelivr.net/npm/zora/dist/index.js"
+      "zora": "https://cdn.jsdelivr.net/npm/zora@6.0.0/dist/index.js"
     }
   }
 </script>

--- a/packages/custom-media-element/test/eager-upgrade.html
+++ b/packages/custom-media-element/test/eager-upgrade.html
@@ -4,7 +4,7 @@
     <script type="importmap">
       {
         "imports": {
-          "zora": "https://cdn.jsdelivr.net/npm/zora/dist/index.js"
+          "zora": "https://cdn.jsdelivr.net/npm/zora@6.0.0/dist/index.js"
         }
       }
     </script>

--- a/packages/custom-media-element/test/lazy-upgrade.html
+++ b/packages/custom-media-element/test/lazy-upgrade.html
@@ -4,7 +4,7 @@
     <script type="importmap">
       {
         "imports": {
-          "zora": "https://cdn.jsdelivr.net/npm/zora/dist/index.js"
+          "zora": "https://cdn.jsdelivr.net/npm/zora@6.0.0/dist/index.js"
         }
       }
     </script>

--- a/packages/dash-video-element/test/index.html
+++ b/packages/dash-video-element/test/index.html
@@ -3,7 +3,7 @@
 <script type="importmap">
   {
     "imports": {
-      "zora": "https://cdn.jsdelivr.net/npm/zora/dist/index.js",
+      "zora": "https://cdn.jsdelivr.net/npm/zora@6.0.0/dist/index.js",
       "super-media-element": "https://cdn.jsdelivr.net/npm/super-media-element",
       "dashjs-esm": "https://cdn.jsdelivr.net/npm/dashjs-esm"
     }

--- a/packages/hls-video-element/test/index.html
+++ b/packages/hls-video-element/test/index.html
@@ -3,7 +3,7 @@
 <script type="importmap">
   {
     "imports": {
-      "zora": "https://cdn.jsdelivr.net/npm/zora/dist/index.js",
+      "zora": "https://cdn.jsdelivr.net/npm/zora@6.0.0/dist/index.js",
       "custom-media-element": "https://cdn.jsdelivr.net/npm/custom-media-element@1.4/+esm",
       "media-tracks": "https://cdn.jsdelivr.net/npm/media-tracks@0.3/+esm",
       "hls.js/": "https://cdn.jsdelivr.net/npm/hls.js@1.6/"

--- a/packages/jwplayer-video-element/test/index.html
+++ b/packages/jwplayer-video-element/test/index.html
@@ -3,7 +3,7 @@
 <script type="importmap">
   {
     "imports": {
-      "zora": "https://cdn.jsdelivr.net/npm/zora/dist/index.js",
+      "zora": "https://cdn.jsdelivr.net/npm/zora@6.0.0/dist/index.js",
       "super-media-element": "https://cdn.jsdelivr.net/npm/super-media-element"
     }
   }

--- a/packages/media-tracks/test/index.html
+++ b/packages/media-tracks/test/index.html
@@ -4,7 +4,7 @@
     <script type="importmap">
       {
         "imports": {
-          "zora": "https://cdn.jsdelivr.net/npm/zora/dist/index.js"
+          "zora": "https://cdn.jsdelivr.net/npm/zora@6.0.0/dist/index.js"
         }
       }
     </script>

--- a/packages/spotify-audio-element/test/index.html
+++ b/packages/spotify-audio-element/test/index.html
@@ -3,7 +3,7 @@
 <script type="importmap">
   {
     "imports": {
-      "zora": "https://cdn.jsdelivr.net/npm/zora/dist/index.js"
+      "zora": "https://cdn.jsdelivr.net/npm/zora@6.0.0/dist/index.js"
     }
   }
 </script>

--- a/packages/super-media-element/test/lazy.html
+++ b/packages/super-media-element/test/lazy.html
@@ -3,7 +3,7 @@
 <script type="importmap">
   {
     "imports": {
-      "zora": "https://cdn.jsdelivr.net/npm/zora/dist/index.js"
+      "zora": "https://cdn.jsdelivr.net/npm/zora@6.0.0/dist/index.js"
     }
   }
 </script>

--- a/packages/tiktok-video-element/test/index.html
+++ b/packages/tiktok-video-element/test/index.html
@@ -3,7 +3,7 @@
 <script type="importmap">
   {
     "imports": {
-      "zora": "https://cdn.jsdelivr.net/npm/zora/dist/index.js"
+      "zora": "https://cdn.jsdelivr.net/npm/zora@6.0.0/dist/index.js"
     }
   }
 </script>

--- a/packages/videojs-video-element/test/index.html
+++ b/packages/videojs-video-element/test/index.html
@@ -3,7 +3,7 @@
 <script type="importmap">
   {
     "imports": {
-      "zora": "https://cdn.jsdelivr.net/npm/zora/dist/index.js",
+      "zora": "https://cdn.jsdelivr.net/npm/zora@6.0.0/dist/index.js",
       "super-media-element": "https://cdn.jsdelivr.net/npm/super-media-element@1.3/+esm",
       "media-tracks": "https://cdn.jsdelivr.net/npm/media-tracks@0.2/+esm"
     }

--- a/packages/vimeo-video-element/test/index.html
+++ b/packages/vimeo-video-element/test/index.html
@@ -3,7 +3,7 @@
 <script type="importmap">
   {
     "imports": {
-      "zora": "https://cdn.jsdelivr.net/npm/zora/dist/index.js",
+      "zora": "https://cdn.jsdelivr.net/npm/zora@6.0.0/dist/index.js",
       "@vimeo/player/": "https://cdn.jsdelivr.net/npm/@vimeo/player/"
     }
   }

--- a/packages/wistia-video-element/test/index.html
+++ b/packages/wistia-video-element/test/index.html
@@ -3,7 +3,7 @@
 <script type="importmap">
   {
     "imports": {
-      "zora": "https://cdn.jsdelivr.net/npm/zora/dist/index.js",
+      "zora": "https://cdn.jsdelivr.net/npm/zora@6.0.0/dist/index.js",
       "super-media-element": "https://cdn.jsdelivr.net/npm/super-media-element"
     }
   }

--- a/packages/youtube-video-element/test/index.html
+++ b/packages/youtube-video-element/test/index.html
@@ -3,7 +3,7 @@
 <script type="importmap">
   {
     "imports": {
-      "zora": "https://cdn.jsdelivr.net/npm/zora/dist/index.js"
+      "zora": "https://cdn.jsdelivr.net/npm/zora@6.0.0/dist/index.js"
     }
   }
 </script>


### PR DESCRIPTION
## Summary

CI is broken repo-wide: unpinned zora CDN import now pulls a Node-only bundle.

All browser tests fail on any PR. Our test pages load `zora` from an unversioned jsDelivr URL, which resolves to `latest`. zora `6.0.4` (published 2026-07-12) added a bare Node import to its browser bundle, so the module graph fails to load and every test page times out.

## Repro

Any PR. Example: https://github.com/muxinc/media-elements/actions/runs/30292383359/job/90064977607

## Cause

Every test page imports:

```html
"zora": "https://cdn.jsdelivr.net/npm/zora/dist/index.js"
```

`zora@6.0.4`'s `dist/index.js` now begins:

```js
import { styleText } from 'node:util';
```

Browsers can't resolve `node:util`, so the import fails before any test executes:

```
Access to script at 'node:util' from origin 'http://localhost:8000' has been blocked by CORS policy:
  Cross origin requests are only supported for protocol schemes: chrome, chrome-extension, chrome-untrusted, data, http, https, isolated-app.
Failed to load resource: net::ERR_FAILED

Timeout of 10000ms exceeded for URL: http://localhost:8000/test/
```

`zora@6.0.0` — the version CI resolved to the last time `main` was green (2026-05-13) — has no such import. There are no intermediate releases; the registry only has `6.0.0` and `6.0.4`.

zora `6.0.4` declares no `browser` field and no separate browser export condition, so there is no browser-safe entry point to switch to:

```json
"exports": { ".": { "import": { "default": "./dist/index.js" }, "require": { "default": "./dist/index.cjs" } } }
```

## Why the failing job name is misleading

Turbo reports whichever task fails first and then tears down the run, so the annotation names one arbitrary package:

```
media-tracks#test: command (.../packages/media-tracks) npm run test exited (1)
Tasks: 4 successful, 31 total
```

Only 4 of 31 tasks completed. All 14 test pages are affected.

## Affected files

- `packages/cloudflare-video-element/test/index.html`
- `packages/custom-media-element/test/eager-upgrade.html`
- `packages/custom-media-element/test/lazy-upgrade.html`
- `packages/dash-video-element/test/index.html`
- `packages/hls-video-element/test/index.html`
- `packages/jwplayer-video-element/test/index.html`
- `packages/media-tracks/test/index.html`
- `packages/spotify-audio-element/test/index.html`
- `packages/super-media-element/test/lazy.html`
- `packages/tiktok-video-element/test/index.html`
- `packages/videojs-video-element/test/index.html`
- `packages/vimeo-video-element/test/index.html`
- `packages/wistia-video-element/test/index.html`
- `packages/youtube-video-element/test/index.html`

## Fix

Pin the version in all 14 importmaps:

```diff
-"zora": "https://cdn.jsdelivr.net/npm/zora/dist/index.js"
+"zora": "https://cdn.jsdelivr.net/npm/zora@6.0.0/dist/index.js"
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test harness CDN importmap changes only; no production runtime or library code is modified.
> 
> **Overview**
> Pins the **zora** test runner CDN import to **`zora@6.0.0`** in **14** package browser test HTML importmaps (replacing the unversioned jsDelivr URL).
> 
> This avoids pulling **zora 6.0.4**, whose browser bundle imports **`node:util`** and breaks module loading in the browser, which was causing repo-wide CI browser test timeouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26f5c7db02da3480409644b5b95fd1a282e074c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->