### PR TITLE
chore: bump node version for cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
       - run: npm ci
       - run: npm test
@@ -53,7 +53,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.releases_created == 'true' }}
 
@@ -64,6 +64,4 @@ jobs:
         if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - run: npm exec -c publish-packages
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         if: ${{ steps.release.outputs.releases_created == 'true' }}


### PR DESCRIPTION
Last release failed - https://github.com/muxinc/media-elements/actions/runs/30300436654/job/90092272004

Trying to fix the same way as it was done for elements.

## Follow up:
The created releases were not pushed to npm registry so they would need to be rolled back and recreated or manually pushed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release-time Node version and how npm auth is supplied for publishes; misconfiguration could break CD or leave packages unpublished until follow-up.
> 
> **Overview**
> Updates the **CD** workflow (`cd.yml`) so **lint**, **test**, and **release** all run on **Node 24** instead of 20, matching the fix used elsewhere after a failed release.
> 
> The **release** job’s `npm exec -c publish-packages` step no longer sets **`NODE_AUTH_TOKEN`**; publishing still uses `setup-node` with the npm registry URL and the job’s existing **`id-token: write`** permission, which fits **`--provenance`** in the publish script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2db8817e9021a42c6b6c896dc240e1724036fd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->